### PR TITLE
Button and dimmer events

### DIFF
--- a/src/bthome_ble/const.py
+++ b/src/bthome_ble/const.py
@@ -243,7 +243,6 @@ MEAS_TYPES: dict[int, MeasTypes] = {
     0x2E: MeasTypes(meas_format=SensorLibrary.HUMIDITY__PERCENTAGE),
     0x2F: MeasTypes(meas_format=SensorLibrary.MOISTURE__PERCENTAGE),
     0x3A: MeasTypes(meas_format=EventDeviceKeys.BUTTON),
-    0x3B: MeasTypes(meas_format=EventDeviceKeys.SWITCH),
     0x3C: MeasTypes(
         meas_format=EventDeviceKeys.DIMMER,
         data_length=2,

--- a/src/bthome_ble/event.py
+++ b/src/bthome_ble/event.py
@@ -20,13 +20,11 @@ class EventDeviceKeys(StrEnum):
 BUTTON_EVENTS: dict[int, str | None] = {
     0x00: None,
     0x01: "press",
-    0x02: "single_press",
-    0x03: "double_press",
-    0x04: "triple_press",
-    0x05: "long_press",
-    0x06: "long_single_press",
-    0x07: "long_double_press",
-    0x08: "long_triple_press",
+    0x02: "double_press",
+    0x03: "triple_press",
+    0x04: "long_press",
+    0x05: "long_double_press",
+    0x06: "long_triple_press",
 }
 
 DIMMER_EVENTS: dict[int, str | None] = {

--- a/src/bthome_ble/event.py
+++ b/src/bthome_ble/event.py
@@ -15,18 +15,20 @@ class EventDeviceKeys(StrEnum):
     BUTTON = "button"
 
 
-EVENT_TYPES: dict[int, str] = {
-    0x01: "turn_on",
-    0x02: "turn_off",
-    0x03: "toggle",
-    0x04: "press",
-    0x05: "single_press",
-    0x06: "double_press",
-    0x07: "triple_press",
-    0x08: "long_press",
-    0x09: "long_single_press",
-    0x0A: "long_double_press",
-    0x0B: "long_triple_press",
-    0x0C: "rotate_left",
-    0x0D: "rotate_right",
+BUTTON_EVENTS: dict[int, str | None] = {
+    0x00: None,
+    0x01: "press",
+    0x02: "single_press",
+    0x03: "double_press",
+    0x04: "triple_press",
+    0x05: "long_press",
+    0x06: "long_single_press",
+    0x07: "long_double_press",
+    0x08: "long_triple_press",
+}
+
+DIMMER_EVENTS: dict[int, str | None] = {
+    0x00: None,
+    0x01: "rotate_left",
+    0x02: "rotate_right",
 }

--- a/src/bthome_ble/event.py
+++ b/src/bthome_ble/event.py
@@ -1,4 +1,6 @@
 """Event constants for BTHome measurements."""
+from __future__ import annotations
+
 from sensor_state_data.enum import StrEnum
 
 

--- a/tests/test_parser_v1.py
+++ b/tests/test_parser_v1.py
@@ -1028,7 +1028,7 @@ def test_bthome_moisture(caplog):
 
 def test_bthome_event_button_long_press(caplog):
     """Test BTHome parser for an event of a long press on a button without encryption."""
-    data_string = b"\x02\x3A\x05"
+    data_string = b"\x02\x3A\x04"
     advertisement = bytes_to_service_info(
         data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
     )

--- a/tests/test_parser_v1.py
+++ b/tests/test_parser_v1.py
@@ -23,6 +23,7 @@ KEY_BATTERY = DeviceKey(key="battery", device_id=None)
 KEY_BINARY_GENERIC = DeviceKey(key="generic", device_id=None)
 KEY_BINARY_OPENING = DeviceKey(key="opening", device_id=None)
 KEY_BINARY_POWER = DeviceKey(key="power", device_id=None)
+KEY_BUTTON = DeviceKey(key="button", device_id=None)
 KEY_CO2 = DeviceKey(key="carbon_dioxide", device_id=None)
 KEY_DIMMER = DeviceKey(key="dimmer", device_id=None)
 KEY_COUNT = DeviceKey(key="count", device_id=None)
@@ -37,7 +38,6 @@ KEY_PM10 = DeviceKey(key="pm10", device_id=None)
 KEY_POWER = DeviceKey(key="power", device_id=None)
 KEY_PRESSURE = DeviceKey(key="pressure", device_id=None)
 KEY_SIGNAL_STRENGTH = DeviceKey(key="signal_strength", device_id=None)
-KEY_SWITCH = DeviceKey(key="switch", device_id=None)
 KEY_TEMPERATURE = DeviceKey(key="temperature", device_id=None)
 KEY_VOC = DeviceKey(key="volatile_organic_compounds", device_id=None)
 KEY_VOLTAGE = DeviceKey(key="voltage", device_id=None)
@@ -1026,9 +1026,9 @@ def test_bthome_moisture(caplog):
     )
 
 
-def test_bthome_event_switch_single_press(caplog):
-    """Test BTHome parser for an event of a single press of a switch without encryption."""
-    data_string = b"\x02\x3B\x05"
+def test_bthome_event_button_long_press(caplog):
+    """Test BTHome parser for an event of a long press on a button without encryption."""
+    data_string = b"\x02\x3A\x05"
     advertisement = bytes_to_service_info(
         data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
     )
@@ -1059,10 +1059,10 @@ def test_bthome_event_switch_single_press(caplog):
             ),
         },
         events={
-            KEY_SWITCH: Event(
-                device_key=KEY_SWITCH,
-                name="Switch",
-                event_type="single_press",
+            KEY_BUTTON: Event(
+                device_key=KEY_BUTTON,
+                name="Button",
+                event_type="long_press",
                 event_properties=None,
             ),
         },
@@ -1071,7 +1071,7 @@ def test_bthome_event_switch_single_press(caplog):
 
 def test_bthome_event_dimmer_rotate_left_3_steps(caplog):
     """Test BTHome parser for an event rotating a dimmer 3 steps left."""
-    data_string = b"\x03\x3C\x0C\x03"
+    data_string = b"\x03\x3C\x01\x03"
     advertisement = bytes_to_service_info(
         data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
     )

--- a/tests/test_parser_v2.py
+++ b/tests/test_parser_v2.py
@@ -1159,7 +1159,7 @@ def test_bthome_moisture(caplog):
 
 def test_bthome_event_button_long_press(caplog):
     """Test BTHome parser for an event of a long press on a button without encryption."""
-    data_string = b"\x40\x3A\x05"
+    data_string = b"\x40\x3A\x04"
     advertisement = bytes_to_service_info(
         data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
     )
@@ -1205,7 +1205,7 @@ def test_bthome_event_triple_button_device(caplog):
     Test BTHome parser for an event of a triple button device where
     the 2nd button is pressed and the 3rd button is triple pressed.
     """
-    data_string = b"\x40\x3A\x00\x3A\x01\x3A\x04"
+    data_string = b"\x40\x3A\x00\x3A\x01\x3A\x03"
     advertisement = bytes_to_service_info(
         data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
     )

--- a/tests/test_parser_v2.py
+++ b/tests/test_parser_v2.py
@@ -284,6 +284,85 @@ def test_bindkey_verified_can_be_unset():
     assert not device.bindkey_verified
 
 
+def test_bthome_wrong_object_id(caplog):
+    """Test BTHome parser for a non-existing Object ID xFE."""
+    data_string = b"\x40\xFE\xca\x09"
+    advertisement = bytes_to_service_info(
+        data_string, local_name="ATC_8D18B2", address="A4:C1:38:8D:18:B2"
+    )
+
+    device = BTHomeBluetoothDeviceData()
+    assert device.update(advertisement) == SensorUpdate(
+        title="ATC 18B2",
+        devices={
+            None: SensorDeviceInfo(
+                name="ATC 18B2",
+                manufacturer="Xiaomi",
+                model="BTHome sensor",
+                sw_version="BTHome BLE v2",
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+        },
+        entity_values={
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60
+            ),
+        },
+    )
+
+
+def test_bthome_battery_wrong_oobject_id_humidity(caplog):
+    """
+    Test BTHome parser for battery, wrong object id and humidity reading.
+    Should only return the battery reading, as humidity is after wrong object id.
+    """
+    data_string = b"\x40\x01\x5d\xfe\x5d\x09\x03\xb7\x18"
+    advertisement = bytes_to_service_info(
+        data_string, local_name="ATC_8D18B2", address="A4:C1:38:8D:18:B2"
+    )
+
+    device = BTHomeBluetoothDeviceData()
+    assert device.update(advertisement) == SensorUpdate(
+        title="ATC 18B2",
+        devices={
+            None: SensorDeviceInfo(
+                name="ATC 18B2",
+                manufacturer="Xiaomi",
+                model="BTHome sensor",
+                sw_version="BTHome BLE v2",
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            KEY_BATTERY: SensorDescription(
+                device_key=KEY_BATTERY,
+                device_class=SensorDeviceClass.BATTERY,
+                native_unit_of_measurement=Units.PERCENTAGE,
+            ),
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+        },
+        entity_values={
+            KEY_BATTERY: SensorValue(
+                device_key=KEY_BATTERY, name="Battery", native_value=93
+            ),
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60
+            ),
+        },
+    )
+
+
 def test_bthome_temperature_humidity(caplog):
     """Test BTHome parser for temperature humidity reading without encryption."""
     data_string = b"\x40\x02\xca\x09\x03\xbf\x13"
@@ -336,7 +415,7 @@ def test_bthome_temperature_humidity(caplog):
 
 def test_bthome_temperature_humidity_battery(caplog):
     """Test BTHome parser for temperature humidity battery reading."""
-    data_string = b"\x40\x02\x5d\x09\x03\xb7\x18\x01\x5d"
+    data_string = b"\x40\x01\x5d\x02\x5d\x09\x03\xb7\x18"
     advertisement = bytes_to_service_info(
         data_string, local_name="ATC_8D18B2", address="A4:C1:38:8D:18:B2"
     )


### PR DESCRIPTION
As proposed in https://github.com/home-assistant/bthome.io/issues/5#issuecomment-1285504858 this PR removes the switch events and changes the evens for buttons and dimmers. 

Button --> events (press, single press, double press, triple press, long press, double long press, triple long press)
Dimmer --> events (rotate right x steps, rotate left x steps)

Also added the option to broadcast "no event", which you will need in case you have a triple button device, and only want to send an event with e.g. the 2nd and 3rd button. As the order of button 1, 2 an 3 has to be the same in each message, it will be required to send "no event (None)" for the first button.

