### PR TITLE
fix: multiple measurements fix

### DIFF
--- a/src/bthome_ble/parser.py
+++ b/src/bthome_ble/parser.py
@@ -313,7 +313,7 @@ class BTHomeBluetoothDeviceData(BluetoothData):
         prev_obj_meas_type = 0
         result = False
         measurements: list[dict[str, Any]] = []
-        device_id_dict: dict[int, int] = {}
+        postfix_dict: dict[int, int] = {}
         obj_data_format: str | int
 
         # Create a list with all individual objects
@@ -390,12 +390,12 @@ class BTHomeBluetoothDeviceData(BluetoothData):
                 continue
 
             if meas["measurement type"] in dup_meas_types:
-                # Add a device_id for advertisements with multiple measurements of the same type
-                device_id_counter = device_id_dict.get(meas["measurement type"], 0) + 1
-                device_id_dict[meas["measurement type"]] = device_id_counter
-                device_id = str(device_id_counter)
+                # Add a postfix for advertisements with multiple measurements of the same type
+                postfix_counter = postfix_dict.get(meas["measurement type"], 0) + 1
+                postfix_dict[meas["measurement type"]] = postfix_counter
+                postfix = f"_{postfix_counter}"
             else:
-                device_id = None
+                postfix = ""
 
             meas_type = MEAS_TYPES[meas["measurement type"]]
             meas_format = meas_type.meas_format
@@ -423,21 +423,19 @@ class BTHomeBluetoothDeviceData(BluetoothData):
                     and meas_format.device_class
                 ):
                     self.update_sensor(
-                        key=str(meas_format.device_class),
+                        key=f"{str(meas_format.device_class)}{postfix}",
                         native_unit_of_measurement=meas_format.native_unit_of_measurement,
                         native_value=value,
                         device_class=meas_format.device_class,
-                        device_id=device_id,
                     )
                 elif (
                     type(meas_format) == BaseBinarySensorDescription
                     and meas_format.device_class
                 ):
                     self.update_binary_sensor(
-                        key=str(meas_format.device_class),
+                        key=f"{str(meas_format.device_class)}{postfix}",
                         device_class=meas_format.device_class,
                         native_value=bool(value),
-                        device_id=device_id,
                     )
                 elif type(meas_format) == EventDeviceKeys:
                     event_type = parse_event_type(
@@ -450,10 +448,9 @@ class BTHomeBluetoothDeviceData(BluetoothData):
                     )
                     if event_type:
                         self.fire_event(
-                            key=str(meas_format),
+                            key=f"{str(meas_format)}{postfix}",
                             event_type=event_type,
                             event_properties=event_properties,
-                            device_id=device_id,
                         )
                 result = True
             else:

--- a/tests/test_parser_v2.py
+++ b/tests/test_parser_v2.py
@@ -1242,15 +1242,15 @@ def test_bthome_event_triple_button_device(caplog):
             ),
         },
         events={
-            DeviceKey(key="button", device_id="2"): Event(
-                device_key=DeviceKey(key="button", device_id="2"),
-                name="Button",
+            DeviceKey(key="button_2", device_id=None): Event(
+                device_key=DeviceKey(key="button_2", device_id=None),
+                name="Button 2",
                 event_type="press",
                 event_properties=None,
             ),
-            DeviceKey(key="button", device_id="3"): Event(
-                device_key=DeviceKey(key="button", device_id="3"),
-                name="Button",
+            DeviceKey(key="button_3", device_id=None): Event(
+                device_key=DeviceKey(key="button_3", device_id=None),
+                name="Button 3",
                 event_type="triple_press",
                 event_properties=None,
             ),
@@ -1665,13 +1665,13 @@ def test_bthome_double_temperature(caplog):
             )
         },
         entity_descriptions={
-            DeviceKey(key="temperature", device_id="1"): SensorDescription(
-                device_key=DeviceKey(key="temperature", device_id="1"),
+            DeviceKey(key="temperature_1", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="temperature_1", device_id=None),
                 device_class=SensorDeviceClass.TEMPERATURE,
                 native_unit_of_measurement=Units.TEMP_CELSIUS,
             ),
-            DeviceKey(key="temperature", device_id="2"): SensorDescription(
-                device_key=DeviceKey(key="temperature", device_id="2"),
+            DeviceKey(key="temperature_2", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="temperature_2", device_id=None),
                 device_class=SensorDeviceClass.TEMPERATURE,
                 native_unit_of_measurement=Units.TEMP_CELSIUS,
             ),
@@ -1682,14 +1682,14 @@ def test_bthome_double_temperature(caplog):
             ),
         },
         entity_values={
-            DeviceKey(key="temperature", device_id="1"): SensorValue(
-                device_key=DeviceKey(key="temperature", device_id="1"),
-                name="Temperature",
+            DeviceKey(key="temperature_1", device_id=None): SensorValue(
+                device_key=DeviceKey(key="temperature_1", device_id=None),
+                name="Temperature 1",
                 native_value=25.06,
             ),
-            DeviceKey(key="temperature", device_id="2"): SensorValue(
-                device_key=DeviceKey(key="temperature", device_id="2"),
-                name="Temperature",
+            DeviceKey(key="temperature_2", device_id=None): SensorValue(
+                device_key=DeviceKey(key="temperature_2", device_id=None),
+                name="Temperature 2",
                 native_value=25.11,
             ),
             KEY_SIGNAL_STRENGTH: SensorValue(
@@ -1699,7 +1699,7 @@ def test_bthome_double_temperature(caplog):
     )
 
 
-def test_bthome_tripple_temperature_double_humidity_battery(caplog):
+def test_bthome_triple_temperature_double_humidity_battery(caplog):
     """
     Test BTHome parser for triple temperature, double humidity and
     single battery reading without encryption.
@@ -1724,28 +1724,28 @@ def test_bthome_tripple_temperature_double_humidity_battery(caplog):
             )
         },
         entity_descriptions={
-            DeviceKey(key="temperature", device_id="1"): SensorDescription(
-                device_key=DeviceKey(key="temperature", device_id="1"),
+            DeviceKey(key="temperature_1", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="temperature_1", device_id=None),
                 device_class=SensorDeviceClass.TEMPERATURE,
                 native_unit_of_measurement=Units.TEMP_CELSIUS,
             ),
-            DeviceKey(key="temperature", device_id="2"): SensorDescription(
-                device_key=DeviceKey(key="temperature", device_id="2"),
+            DeviceKey(key="temperature_2", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="temperature_2", device_id=None),
                 device_class=SensorDeviceClass.TEMPERATURE,
                 native_unit_of_measurement=Units.TEMP_CELSIUS,
             ),
-            DeviceKey(key="temperature", device_id="3"): SensorDescription(
-                device_key=DeviceKey(key="temperature", device_id="3"),
+            DeviceKey(key="temperature_3", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="temperature_3", device_id=None),
                 device_class=SensorDeviceClass.TEMPERATURE,
                 native_unit_of_measurement=Units.TEMP_CELSIUS,
             ),
-            DeviceKey(key="humidity", device_id="1"): SensorDescription(
-                device_key=DeviceKey(key="humidity", device_id="1"),
+            DeviceKey(key="humidity_1", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="humidity_1", device_id=None),
                 device_class=SensorDeviceClass.HUMIDITY,
                 native_unit_of_measurement=Units.PERCENTAGE,
             ),
-            DeviceKey(key="humidity", device_id="2"): SensorDescription(
-                device_key=DeviceKey(key="humidity", device_id="2"),
+            DeviceKey(key="humidity_2", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="humidity_2", device_id=None),
                 device_class=SensorDeviceClass.HUMIDITY,
                 native_unit_of_measurement=Units.PERCENTAGE,
             ),
@@ -1761,29 +1761,29 @@ def test_bthome_tripple_temperature_double_humidity_battery(caplog):
             ),
         },
         entity_values={
-            DeviceKey(key="temperature", device_id="1"): SensorValue(
-                device_key=DeviceKey(key="temperature", device_id="1"),
-                name="Temperature",
+            DeviceKey(key="temperature_1", device_id=None): SensorValue(
+                device_key=DeviceKey(key="temperature_1", device_id=None),
+                name="Temperature 1",
                 native_value=25.06,
             ),
-            DeviceKey(key="temperature", device_id="2"): SensorValue(
-                device_key=DeviceKey(key="temperature", device_id="2"),
-                name="Temperature",
+            DeviceKey(key="temperature_2", device_id=None): SensorValue(
+                device_key=DeviceKey(key="temperature_2", device_id=None),
+                name="Temperature 2",
                 native_value=25.11,
             ),
-            DeviceKey(key="temperature", device_id="3"): SensorValue(
-                device_key=DeviceKey(key="temperature", device_id="3"),
-                name="Temperature",
+            DeviceKey(key="temperature_3", device_id=None): SensorValue(
+                device_key=DeviceKey(key="temperature_3", device_id=None),
+                name="Temperature 3",
                 native_value=22.55,
             ),
-            DeviceKey(key="humidity", device_id="1"): SensorValue(
-                device_key=DeviceKey(key="humidity", device_id="1"),
-                name="Humidity",
+            DeviceKey(key="humidity_1", device_id=None): SensorValue(
+                device_key=DeviceKey(key="humidity_1", device_id=None),
+                name="Humidity 1",
                 native_value=63.27,
             ),
-            DeviceKey(key="humidity", device_id="2"): SensorValue(
-                device_key=DeviceKey(key="humidity", device_id="2"),
-                name="Humidity",
+            DeviceKey(key="humidity_2", device_id=None): SensorValue(
+                device_key=DeviceKey(key="humidity_2", device_id=None),
+                name="Humidity 2",
                 native_value=60.71,
             ),
             KEY_BATTERY: SensorValue(KEY_BATTERY, name="Battery", native_value=93),


### PR DESCRIPTION
I ran into the "problem" that the current implementation for multiple measurements of the same type (e.g. 3 temperatures), will result in three devices (1, 2 and 3) in Home Assistant. This is caused by the fact that I had defined one device_id per temperature. However, this is more meant for thinks like an indoor and outdoor temperature device that report via the indoor device.  

I now have changed it such that we always have one device (`device_id = None`). Each measurement will get a postfix, in case there are more than one of that type. E.g. temperature_1, temperature_2 etc, with name Temperature 1, Temperature 2, etc. 