### PR TITLE
feat: remove cipher update

### DIFF
--- a/src/bthome_ble/bthome_v2_encryption.py
+++ b/src/bthome_ble/bthome_v2_encryption.py
@@ -26,7 +26,6 @@ def decrypt_payload(
     print("CryptData:", payload.hex())
     print("Mic:", mic.hex())
     cipher = AES.new(key, AES.MODE_CCM, nonce=nonce, mac_len=4)
-    cipher.update(b"\x11")
     print()
     print("Starting Decryption data")
     try:
@@ -71,7 +70,6 @@ def encrypt_payload(
     """Encrypt payload."""
     nonce = b"".join([mac, uuid16, sw_version, count_id])  # 6+2+1+4 = 13 bytes
     cipher = AES.new(key, AES.MODE_CCM, nonce=nonce, mac_len=4)
-    cipher.update(b"\x11")
     ciphertext, mic = cipher.encrypt_and_digest(data)
     print("MAC:", mac.hex())
     print("Binkey:", key.hex())
@@ -96,7 +94,7 @@ def main() -> None:
     count_id = bytes(bytearray.fromhex("00112233"))  # count id (change every message)
     mac = binascii.unhexlify("5448E68F80A5")  # MAC
     uuid16 = b"\xD2\xFC"
-    sw_version = b"\x42"
+    sw_version = b"\x41"
     bindkey = binascii.unhexlify("231d39c1d7cc1ab1aee224cd096db932")
 
     payload = encrypt_payload(

--- a/src/bthome_ble/parser.py
+++ b/src/bthome_ble/parser.py
@@ -493,7 +493,8 @@ class BTHomeBluetoothDeviceData(BluetoothData):
         # nonce: mac [6], uuid16 [2 (v1) or 3 (v2)], count_id [4]
         nonce = b"".join([bthome_mac, uuid, count_id])
         cipher = AES.new(self.bindkey, AES.MODE_CCM, nonce=nonce, mac_len=4)
-        cipher.update(b"\x11")
+        if sw_version == 1:
+            cipher.update(b"\x11")
 
         # decrypt the data
         try:

--- a/tests/test_parser_v2.py
+++ b/tests/test_parser_v2.py
@@ -221,7 +221,7 @@ def test_bindkey_wrong():
 def test_bindkey_correct():
     """Test BTHome parser with correct encryption key."""
     bindkey = "231d39c1d7cc1ab1aee224cd096db932"
-    data_string = b"\x41\xa4\x72\x66\xc9\x5f\x73\x00\x11\x22\x33\xb7\xce\xd8\xe5"
+    data_string = b"\x41\xa4\x72\x66\xc9\x5f\x73\x00\x11\x22\x33\x78\x23\x72\x14"
     advertisement = bytes_to_service_info(
         data_string,
         local_name="TEST DEVICE",
@@ -276,7 +276,7 @@ def test_bindkey_correct():
 def test_bindkey_verified_can_be_unset():
     """Test BTHome parser with wrong encryption key."""
     bindkey = "814aac74c4f17b6c1581e1ab87816b99"
-    data_string = b'\x41\xfb\xa45\xe4\xd3\xc3\x12\xfb\x00\x11"3W\xd9\n\x99'
+    data_string = b"\x41\xa4\x72\x66\xc9\x5f\x73\x00\x11\x22\x33\x78\x23\x72\x14"
     advertisement = bytes_to_service_info(
         data_string,
         local_name="ATC_8D18B2",

--- a/tests/test_v2_encryption.py
+++ b/tests/test_v2_encryption.py
@@ -10,7 +10,7 @@ def test_encryption_example():
     count_id = bytes(bytearray.fromhex("00112233"))  # count id (change every message)
     mac = binascii.unhexlify("5448E68F80A5")  # MAC
     uuid16 = b"\xd2\xfc"
-    sw_version = b"\x42"
+    sw_version = b"\x41"
     bindkey = binascii.unhexlify("231d39c1d7cc1ab1aee224cd096db932")
 
     encrypted_payload = encrypt_payload(
@@ -23,7 +23,7 @@ def test_encryption_example():
     )
     assert (
         encrypted_payload
-        == b"\xd2\xfc\x42\x69\x6c\x8c\x91\x85\x6f\x00\x11\x22\x33\x04\x5b\xbc\x2a"
+        == b"\xd2\xfc\x41\xa4\x72\x66\xc9\x5f\x73\x00\x11\x22\x33\x78\x23\x72\x14"
     )
     assert decrypt_aes_ccm(key=bindkey, mac=mac, data=encrypted_payload) == {
         "humidity": 50.55,


### PR DESCRIPTION
As discussed in #20, this PR proposes to remove the `cipher.update(b"\x11")` in the decryption code for BTHome V2. This will remove the need to apply this in the sensor firmware code as well. 

In V1, this `cipher.update(b"\x11")` will be remained as it was, to keep backward compatibility. V2 isn't used most likely at the moment, as Home Assistant will be updated in the December release with V2 support. 

