### PR TITLE
fix: warning for numerical order object id

### DIFF
--- a/src/bthome_ble/bthome_v2_encryption.py
+++ b/src/bthome_ble/bthome_v2_encryption.py
@@ -23,8 +23,8 @@ def decrypt_payload(
 ) -> dict[str, float] | None:
     """Decrypt payload."""
     print("Nonce:", nonce.hex())
-    print("CryptData:", payload.hex())
-    print("Mic:", mic.hex())
+    print("Ciphertext:", payload.hex())
+    print("MIC:", mic.hex())
     cipher = AES.new(key, AES.MODE_CCM, nonce=nonce, mac_len=4)
     print()
     print("Starting Decryption data")
@@ -75,7 +75,8 @@ def encrypt_payload(
     print("Binkey:", key.hex())
     print("Data:", data.hex())
     print("Nonce:", nonce.hex())
-    print("CryptData:", ciphertext.hex(), "Mic:", mic.hex())
+    print("Ciphertext:", ciphertext.hex())
+    print("MIC:", mic.hex())
     return b"".join([uuid16, sw_version, ciphertext, count_id, mic])
 
 

--- a/src/bthome_ble/parser.py
+++ b/src/bthome_ble/parser.py
@@ -331,7 +331,7 @@ class BTHomeBluetoothDeviceData(BluetoothData):
             else:
                 # BTHome V2
                 obj_meas_type = payload[obj_start]
-                if prev_obj_meas_type < obj_meas_type:
+                if prev_obj_meas_type > obj_meas_type:
                     _LOGGER.warning(
                         "BTHome device is not sending object ids in numerical order (from low to "
                         "high object id). This can cause issues with your BTHome receiver, "


### PR DESCRIPTION
Fix for warning for numerical order object id. Check was reversed.
Updated the encryption example to be in line with the documentation