### PR TITLE
feat: timestamp acceleration and gyroscope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       # - Create GitHub release
       # - Publish to PyPI
       - name: Python Semantic Release
-        uses: relekang/python-semantic-release@v7.33.1
+        uses: relekang/python-semantic-release@v7.33.4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,12 +9,12 @@ ci:
 
 repos:
   - repo: https://github.com/commitizen-tools/commitizen
-    rev: v2.29.5
+    rev: v3.2.2
     hooks:
       - id: commitizen
         stages: [commit-msg]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: debug-statements
       - id: check-builtin-literals
@@ -34,7 +34,7 @@ repos:
       - id: prettier
         args: ["--tab-width", "2"]
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.37.3
+    rev: v3.4.0
     hooks:
       - id: pyupgrade
         args: [--py37-plus]
@@ -43,22 +43,22 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 23.3.0
     hooks:
       - id: black
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
+    rev: v2.2.4
     hooks:
       - id: codespell
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.931
+    rev: v1.3.0
     hooks:
       - id: mypy
-        additional_dependencies: []
+        additional_dependencies: [types-pytz>=2023.3.0.0]
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.4
     hooks:

--- a/poetry.lock
+++ b/poetry.lock
@@ -333,10 +333,10 @@ testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtuale
 
 [[package]]
 name = "pytz"
-version = "2022.7"
+version = "2023.3"
 description = "World timezone definitions, modern and historical"
 category = "main"
-optional = true
+optional = false
 python-versions = "*"
 
 [[package]]
@@ -367,7 +367,7 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "sensor-state-data"
-version = "2.14.0"
+version = "2.15.1"
 description = "Models for storing and converting Sensor Data state"
 category = "main"
 optional = false
@@ -549,7 +549,7 @@ docs = ["myst-parser", "Sphinx", "sphinx-rtd-theme"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "ec5a646bdbeb275999c44417f2639ee7f0bd3847d6a383351a65a53426f63eb1"
+content-hash = "322de3bc729d5f7af62b3d2fc8cc56106b57623dfc51b88c4fcca3ddbea6998c"
 
 [metadata.files]
 alabaster = [
@@ -776,8 +776,8 @@ pytest-cov = [
     {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
 ]
 pytz = [
-    {file = "pytz-2022.7-py2.py3-none-any.whl", hash = "sha256:93007def75ae22f7cd991c84e02d434876818661f8df9ad5df9e950ff4e52cfd"},
-    {file = "pytz-2022.7.tar.gz", hash = "sha256:7ccfae7b4b2c067464a6733c6261673fdb8fd1be905460396b97a073e9fa683a"},
+    {file = "pytz-2023.3-py2.py3-none-any.whl", hash = "sha256:a151b3abb88eda1d4e34a9814df37de2a80e301e68ba0fd856fb9b46bfbbbffb"},
+    {file = "pytz-2023.3.tar.gz", hash = "sha256:1d8ce29db189191fb55338ee6d0387d82ab59f3d00eac103412d64e0ebd0c588"},
 ]
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
@@ -819,8 +819,8 @@ requests = [
     {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
 ]
 sensor-state-data = [
-    {file = "sensor_state_data-2.14.0-py3-none-any.whl", hash = "sha256:c966f8e6ce004ef1f8350dbf380b6eebf93df98af412917f120b70fe1c583e88"},
-    {file = "sensor_state_data-2.14.0.tar.gz", hash = "sha256:48a9aa94d90a5b294aa204d942d55ddfd58285e8cf801dea7e2eb6ca4dee26e2"},
+    {file = "sensor_state_data-2.15.1-py3-none-any.whl", hash = "sha256:348f8618370caae6e2d1d023f267b0e9da2a8f8b04e24d90b369356d6023b2ea"},
+    {file = "sensor_state_data-2.15.1.tar.gz", hash = "sha256:51f9390617529345a5cceb29c7ba7003f9a9f2f170c0572a6e4a4bbe8bf75a7f"},
 ]
 snowballstemmer = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,9 @@ sphinx-rtd-theme = {version = "^1.0", optional = true}
 myst-parser = {version = "^0.18", optional = true}
 bluetooth-sensor-state-data = ">=1.6.1"
 pycryptodomex = ">=3.15.0"
-sensor-state-data = ">=2.14.0"
+sensor-state-data = ">=2.15.1"
 bluetooth-data-tools = ">=0.1.2"
+pytz = "^2023.3"
 
 [tool.poetry.extras]
 docs = [

--- a/src/bthome_ble/const.py
+++ b/src/bthome_ble/const.py
@@ -342,4 +342,19 @@ MEAS_TYPES: dict[int, MeasTypes] = {
         data_length=4,
         factor=0.001,
     ),
+    0x50: MeasTypes(
+        meas_format=SensorLibrary.TIMESTAMP__NONE,
+        data_length=4,
+        data_format="timestamp",
+    ),
+    0x51: MeasTypes(
+        meas_format=SensorLibrary.ACCELERATION__ACCELERATION_METERS_PER_SQUARE_SECOND,
+        data_length=2,
+        factor=0.001,
+    ),
+    0x52: MeasTypes(
+        meas_format=SensorLibrary.GYROSCOPE__GYROSCOPE_DEGREES_PER_SECOND,
+        data_length=2,
+        factor=0.001,
+    ),
 }

--- a/src/bthome_ble/parser.py
+++ b/src/bthome_ble/parser.py
@@ -84,7 +84,8 @@ def parse_string(data_obj: bytes) -> str:
 
 def parse_timestamp(data_obj: bytes) -> datetime:
     """Convert bytes to a datetime object."""
-    value = datetime.fromtimestamp(int.from_bytes(data_obj, "little", signed=False))
+    value = datetime.utcfromtimestamp(int.from_bytes(data_obj, "little", signed=False))
+    _LOGGER.error("time %s", value)
     return pytz.utc.localize(value)
 
 

--- a/tests/test_parser_v1.py
+++ b/tests/test_parser_v1.py
@@ -983,7 +983,7 @@ def test_bthome_timestamp(caplog):
             KEY_TIMESTAMP: SensorValue(
                 device_key=KEY_TIMESTAMP,
                 name="Timestamp",
-                native_value=datetime(2023, 5, 14, 20, 41, 17, tzinfo=timezone.utc),
+                native_value=datetime(2023, 5, 14, 19, 41, 17, tzinfo=timezone.utc),
             ),
             KEY_SIGNAL_STRENGTH: SensorValue(
                 device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60

--- a/tests/test_parser_v2.py
+++ b/tests/test_parser_v2.py
@@ -2291,7 +2291,7 @@ def test_bthome_timestamp(caplog):
             KEY_TIMESTAMP: SensorValue(
                 device_key=KEY_TIMESTAMP,
                 name="Timestamp",
-                native_value=datetime(2023, 5, 14, 20, 41, 17, tzinfo=timezone.utc),
+                native_value=datetime(2023, 5, 14, 19, 41, 17, tzinfo=timezone.utc),
             ),
             KEY_SIGNAL_STRENGTH: SensorValue(
                 device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60

--- a/tests/test_parser_v2.py
+++ b/tests/test_parser_v2.py
@@ -1,5 +1,6 @@
 """Tests for the parser of BLE advertisements in BTHome V2 format."""
 import logging
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
@@ -19,6 +20,7 @@ from sensor_state_data import (
 
 from bthome_ble.parser import BTHomeBluetoothDeviceData, EncryptionScheme
 
+KEY_ACCELERATION = DeviceKey(key="acceleration", device_id=None)
 KEY_BATTERY = DeviceKey(key="battery", device_id=None)
 KEY_BINARY_GENERIC = DeviceKey(key="generic", device_id=None)
 KEY_BINARY_OPENING = DeviceKey(key="opening", device_id=None)
@@ -34,6 +36,7 @@ KEY_DEW_POINT = DeviceKey(key="dew_point", device_id=None)
 KEY_DURATION = DeviceKey(key="duration", device_id=None)
 KEY_ENERGY = DeviceKey(key="energy", device_id=None)
 KEY_GAS = DeviceKey(key="gas", device_id=None)
+KEY_GYROSCOPE = DeviceKey(key="gyroscope", device_id=None)
 KEY_HUMIDITY = DeviceKey(key="humidity", device_id=None)
 KEY_ILLUMINANCE = DeviceKey(key="illuminance", device_id=None)
 KEY_MASS = DeviceKey(key="mass", device_id=None)
@@ -47,6 +50,7 @@ KEY_ROTATION = DeviceKey(key="rotation", device_id=None)
 KEY_SIGNAL_STRENGTH = DeviceKey(key="signal_strength", device_id=None)
 KEY_SPEED = DeviceKey(key="speed", device_id=None)
 KEY_TEMPERATURE = DeviceKey(key="temperature", device_id=None)
+KEY_TIMESTAMP = DeviceKey(key="timestamp", device_id=None)
 KEY_UV_INDEX = DeviceKey(key="uv_index", device_id=None)
 KEY_VOC = DeviceKey(key="volatile_organic_compounds", device_id=None)
 KEY_VOLTAGE = DeviceKey(key="voltage", device_id=None)
@@ -1531,6 +1535,42 @@ def test_bthome_rotation(caplog):
     )
 
 
+def test_bthome_invalid_button_event(caplog):
+    """Test BTHome parser for an invalid button event."""
+    data_string = b"\x40\x3A\xFE"
+    advertisement = bytes_to_service_info(
+        data_string, local_name="SBBT-002C", address="A4:C1:38:8D:18:B2"
+    )
+
+    device = BTHomeBluetoothDeviceData()
+
+    assert device.update(advertisement) == SensorUpdate(
+        title="Shelly BLU Button1 18B2",
+        devices={
+            None: SensorDeviceInfo(
+                name="Shelly BLU Button1 18B2",
+                manufacturer="Shelly",
+                model="BLU Button1",
+                sw_version="BTHome BLE v2",
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+        },
+        entity_values={
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60
+            ),
+        },
+        events={},
+    )
+
+
 def test_bthome_distance_millimeters(caplog):
     """Test BTHome parser for distance in millimeters."""
     data_string = b"\x40\x40\x0C\x00"
@@ -2207,6 +2247,137 @@ def test_bthome_volume_water(caplog):
         entity_values={
             KEY_WATER: SensorValue(
                 device_key=KEY_WATER, name="Water", native_value=19551.879
+            ),
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60
+            ),
+        },
+    )
+
+
+def test_bthome_timestamp(caplog):
+    """Test BTHome parser for Unix timestamp (seconds from 1-1-1970)."""
+    data_string = b"\x44\x50\x5D\x39\x61\x64"
+    advertisement = bytes_to_service_info(
+        data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
+    )
+
+    device = BTHomeBluetoothDeviceData()
+
+    assert device.update(advertisement) == SensorUpdate(
+        title="TEST DEVICE 18B2",
+        devices={
+            None: SensorDeviceInfo(
+                name="TEST DEVICE 18B2",
+                manufacturer=None,
+                model="BTHome sensor (trigger based device)",
+                sw_version="BTHome BLE v2",
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            KEY_TIMESTAMP: SensorDescription(
+                device_key=KEY_TIMESTAMP,
+                device_class=SensorDeviceClass.TIMESTAMP,
+                native_unit_of_measurement=None,
+            ),
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+        },
+        entity_values={
+            KEY_TIMESTAMP: SensorValue(
+                device_key=KEY_TIMESTAMP,
+                name="Timestamp",
+                native_value=datetime(2023, 5, 14, 20, 41, 17, tzinfo=timezone.utc),
+            ),
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60
+            ),
+        },
+    )
+
+
+def test_bthome_acceleration(caplog):
+    """Test BTHome parser for acceleration in m/s°."""
+    data_string = b"\x44\x51\x87\x56"
+    advertisement = bytes_to_service_info(
+        data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
+    )
+
+    device = BTHomeBluetoothDeviceData()
+
+    assert device.update(advertisement) == SensorUpdate(
+        title="TEST DEVICE 18B2",
+        devices={
+            None: SensorDeviceInfo(
+                name="TEST DEVICE 18B2",
+                manufacturer=None,
+                model="BTHome sensor (trigger based device)",
+                sw_version="BTHome BLE v2",
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            KEY_ACCELERATION: SensorDescription(
+                device_key=KEY_ACCELERATION,
+                device_class=SensorDeviceClass.ACCELERATION,
+                native_unit_of_measurement=Units.ACCELERATION_METERS_PER_SQUARE_SECOND,
+            ),
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+        },
+        entity_values={
+            KEY_ACCELERATION: SensorValue(
+                device_key=KEY_ACCELERATION, name="Acceleration", native_value=22.151
+            ),
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60
+            ),
+        },
+    )
+
+
+def test_bthome_gyroscope(caplog):
+    """Test BTHome parser for gyroscope in °/s."""
+    data_string = b"\x44\x52\x87\x56"
+    advertisement = bytes_to_service_info(
+        data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
+    )
+
+    device = BTHomeBluetoothDeviceData()
+
+    assert device.update(advertisement) == SensorUpdate(
+        title="TEST DEVICE 18B2",
+        devices={
+            None: SensorDeviceInfo(
+                name="TEST DEVICE 18B2",
+                manufacturer=None,
+                model="BTHome sensor (trigger based device)",
+                sw_version="BTHome BLE v2",
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            KEY_GYROSCOPE: SensorDescription(
+                device_key=KEY_GYROSCOPE,
+                device_class=SensorDeviceClass.GYROSCOPE,
+                native_unit_of_measurement=Units.GYROSCOPE_DEGREES_PER_SECOND,
+            ),
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+        },
+        entity_values={
+            KEY_GYROSCOPE: SensorValue(
+                device_key=KEY_GYROSCOPE, name="Gyroscope", native_value=22.151
             ),
             KEY_SIGNAL_STRENGTH: SensorValue(
                 device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60


### PR DESCRIPTION
add new sensor types
- timestamp
- acceleration (m/s^2)
- gyroscope (°/s)

fix for KeyError with Shelly BLU button (https://github.com/home-assistant/core/issues/92758)