### PR TITLE
feat: add text sensor

### DIFF
--- a/src/bthome_ble/const.py
+++ b/src/bthome_ble/const.py
@@ -2,7 +2,12 @@
 import dataclasses
 from typing import Union
 
-from sensor_state_data import BinarySensorDeviceClass, SensorLibrary, description
+from sensor_state_data import (
+    BaseDeviceClass,
+    BinarySensorDeviceClass,
+    SensorLibrary,
+    description,
+)
 
 from .event import EventDeviceKeys
 
@@ -17,6 +22,22 @@ class MeasTypes:
     data_length: int = 1
     data_format: str = "unsigned_integer"
     factor: float = 1
+
+
+class ExtendedSensorDeviceClass(BaseDeviceClass):
+    """Device class for additional sensors (compared to sensor-state-data)."""
+
+    # Text
+    TEXT = "text"
+
+
+class ExtendedSensorLibrary(SensorLibrary):
+    """Sensor Library for additional sensors (compared to sensor-state-data)."""
+
+    TEXT__NONE = description.BaseSensorDescription(
+        device_class=ExtendedSensorDeviceClass.TEXT,
+        native_unit_of_measurement=None,
+    )
 
 
 MEAS_TYPES: dict[int, MeasTypes] = {
@@ -356,5 +377,9 @@ MEAS_TYPES: dict[int, MeasTypes] = {
         meas_format=SensorLibrary.GYROSCOPE__GYROSCOPE_DEGREES_PER_SECOND,
         data_length=2,
         factor=0.001,
+    ),
+    0x53: MeasTypes(
+        meas_format=ExtendedSensorLibrary.TEXT__NONE,
+        data_format="string",
     ),
 }

--- a/src/bthome_ble/parser.py
+++ b/src/bthome_ble/parser.py
@@ -423,7 +423,6 @@ class BTHomeBluetoothDeviceData(BluetoothData):
                     "device id": None,
                 }
             )
-            _LOGGER.error("data %s", payload[obj_data_start:next_obj_start])
 
         # Get a list of measurement types that are included more than once.
         seen_meas_formats = set()

--- a/src/bthome_ble/parser.py
+++ b/src/bthome_ble/parser.py
@@ -78,9 +78,15 @@ def parse_float(data_obj: bytes, factor: float = 1.0) -> float | None:
     return round(val * factor, decimal_places)
 
 
-def parse_string(data_obj: bytes) -> str:
+def parse_string(data_obj: bytes) -> str | None:
     """Convert bytes to string."""
-    return data_obj.decode("UTF-8")
+    try:
+        return data_obj.decode("UTF-8")
+    except UnicodeDecodeError:
+        _LOGGER.error(
+            "BTHome data contains bytes that can't be decoded to a string (use UTF-8 encoding)"
+        )
+        return None
 
 
 def parse_timestamp(data_obj: bytes) -> datetime:
@@ -388,10 +394,15 @@ class BTHomeBluetoothDeviceData(BluetoothData):
                     )
                     break
                 prev_obj_meas_type = obj_meas_type
-                obj_data_length = MEAS_TYPES[obj_meas_type].data_length
                 obj_data_format = MEAS_TYPES[obj_meas_type].data_format
-                obj_data_start = obj_start + 1
-                next_obj_start = obj_start + obj_data_length + 1
+
+                if obj_data_format == "string":
+                    obj_data_length = payload[obj_start + 1]
+                    obj_data_start = obj_start + 2
+                else:
+                    obj_data_length = MEAS_TYPES[obj_meas_type].data_length
+                    obj_data_start = obj_start + 1
+                next_obj_start = obj_data_start + obj_data_length
 
             if obj_data_length == 0:
                 _LOGGER.debug(
@@ -412,6 +423,7 @@ class BTHomeBluetoothDeviceData(BluetoothData):
                     "device id": None,
                 }
             )
+            _LOGGER.error("data %s", payload[obj_data_start:next_obj_start])
 
         # Get a list of measurement types that are included more than once.
         seen_meas_formats = set()

--- a/tests/test_parser_v2.py
+++ b/tests/test_parser_v2.py
@@ -18,6 +18,7 @@ from sensor_state_data import (
     Units,
 )
 
+from bthome_ble.const import ExtendedSensorDeviceClass
 from bthome_ble.parser import BTHomeBluetoothDeviceData, EncryptionScheme
 
 KEY_ACCELERATION = DeviceKey(key="acceleration", device_id=None)
@@ -50,6 +51,7 @@ KEY_ROTATION = DeviceKey(key="rotation", device_id=None)
 KEY_SIGNAL_STRENGTH = DeviceKey(key="signal_strength", device_id=None)
 KEY_SPEED = DeviceKey(key="speed", device_id=None)
 KEY_TEMPERATURE = DeviceKey(key="temperature", device_id=None)
+KEY_TEXT = DeviceKey(key="text", device_id=None)
 KEY_TIMESTAMP = DeviceKey(key="timestamp", device_id=None)
 KEY_UV_INDEX = DeviceKey(key="uv_index", device_id=None)
 KEY_VOC = DeviceKey(key="volatile_organic_compounds", device_id=None)
@@ -2451,6 +2453,84 @@ def test_bthome_gyroscope(caplog):
             KEY_GYROSCOPE: SensorValue(
                 device_key=KEY_GYROSCOPE, name="Gyroscope", native_value=22.151
             ),
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60
+            ),
+        },
+    )
+
+
+def test_bthome_text(caplog):
+    """Test BTHome parser for text."""
+    data_string = b"\x44\x53\x0C\x48\x65\x6C\x6C\x6F\x20\x57\x6F\x72\x6C\x64\x21"
+    advertisement = bytes_to_service_info(
+        data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
+    )
+
+    device = BTHomeBluetoothDeviceData()
+
+    assert device.update(advertisement) == SensorUpdate(
+        title="TEST DEVICE 18B2",
+        devices={
+            None: SensorDeviceInfo(
+                name="TEST DEVICE 18B2",
+                manufacturer=None,
+                model="BTHome sensor",
+                sw_version="BTHome BLE v2",
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            KEY_TEXT: SensorDescription(
+                device_key=KEY_TEXT,
+                device_class=ExtendedSensorDeviceClass.TEXT,
+                native_unit_of_measurement=None,
+            ),
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+        },
+        entity_values={
+            KEY_TEXT: SensorValue(
+                device_key=KEY_TEXT, name="Text", native_value="Hello World!"
+            ),
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60
+            ),
+        },
+    )
+
+
+def test_bthome_text_invalid(caplog):
+    """Test BTHome parser for text sensor with invalid format."""
+    data_string = b"\x44\x53\x01\x87"
+    advertisement = bytes_to_service_info(
+        data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
+    )
+
+    device = BTHomeBluetoothDeviceData()
+
+    assert device.update(advertisement) == SensorUpdate(
+        title="TEST DEVICE 18B2",
+        devices={
+            None: SensorDeviceInfo(
+                name="TEST DEVICE 18B2",
+                manufacturer=None,
+                model="BTHome sensor",
+                sw_version="BTHome BLE v2",
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+        },
+        entity_values={
             KEY_SIGNAL_STRENGTH: SensorValue(
                 device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60
             ),


### PR DESCRIPTION
This PR adds a text sensor (fix for #74). 

This data object for a text sensor is variable in size, therefore, the first byte after the byte with the object will have to specify the length of the text. The encoding of the text string should be UTF-8. 

Example
`\x44\x53\x0C\x48\x65\x6C\x6C\x6F\x20\x57\x6F\x72\x6C\x64\x21`

`\x44` = BTHome Device Information
`\x53` = Object id for a text sensor
`\x0C` = Length of the text (12 characters)
`\x48\x65\x6C\x6C\x6F\x20\x57\x6F\x72\x6C\x64\x21` = Text `Hello World!`