### PR TITLE
fix: fix encryption counter

### DIFF
--- a/src/bthome_ble/const.py
+++ b/src/bthome_ble/const.py
@@ -34,8 +34,8 @@ class ExtendedSensorDeviceClass(BaseDeviceClass):
     # Text
     TEXT = "text"
 
-    # Water storage
-    WATER_STORAGE = "water_storage"
+    # Volume storage
+    VOLUME_STORAGE = "volume_storage"
 
 
 class ExtendedSensorLibrary(SensorLibrary):
@@ -51,8 +51,8 @@ class ExtendedSensorLibrary(SensorLibrary):
         native_unit_of_measurement=None,
     )
 
-    WATER_STORAGE__VOLUME_LITERS = description.BaseSensorDescription(
-        device_class=ExtendedSensorDeviceClass.WATER_STORAGE,
+    VOLUME_STORAGE__VOLUME_LITERS = description.BaseSensorDescription(
+        device_class=ExtendedSensorDeviceClass.VOLUME_STORAGE,
         native_unit_of_measurement=Units.VOLUME_LITERS,
     )
 
@@ -404,7 +404,7 @@ MEAS_TYPES: dict[int, MeasTypes] = {
         data_format="raw",
     ),
     0x55: MeasTypes(
-        meas_format=ExtendedSensorLibrary.WATER_STORAGE__VOLUME_LITERS,
+        meas_format=ExtendedSensorLibrary.VOLUME_STORAGE__VOLUME_LITERS,
         data_length=4,
         factor=0.001,
     ),

--- a/src/bthome_ble/parser.py
+++ b/src/bthome_ble/parser.py
@@ -583,34 +583,18 @@ class BTHomeBluetoothDeviceData(BluetoothData):
 
         # verify that the encryption counter is the same or increasing, compared the previous value
         if (
-            self.last_service_info
-            and new_encryption_counter == last_encryption_counter
-            and service_info.service_data == self.last_service_info.service_data
+            new_encryption_counter < last_encryption_counter
             and self.bindkey_verified is True
         ):
-            # the counter and service data are exactly the same as the previous, skipping the adv.
-            _LOGGER.debug(
-                "The new encryption counter (%i) and service data are the same as the previous "
-                "encryption counter (%i) and service data. Skipping this message.",
-                new_encryption_counter,
-                last_encryption_counter,
-            )
-            raise ValueError
-        elif (
-            new_encryption_counter <= last_encryption_counter
-            and self.bindkey_verified is True
-        ):
-            # the counter is lower than the previous counter or equal, but with different service
-            # data.
             if new_encryption_counter < 100 and last_encryption_counter >= 4294967195:
-                # the counter has (most likely) restarted from 0 after reaching the highest number.
+                # the counter has (most likely) restarted from 0 after reaching the highest number
                 self.encryption_counter = new_encryption_counter
             else:
                 # in all other cases, we assume the data has been comprimised and skip the
                 # advertisement
                 _LOGGER.warning(
-                    "The new encryption counter (%i) is lower than or equal to the previous value "
-                    "(%i). The data might be compromised. BLE advertisement will be skipped.",
+                    "The new encryption counter (%i) is lower than the previous value (%i). "
+                    "The data might be compromised. BLE advertisement will be skipped.",
                     new_encryption_counter,
                     last_encryption_counter,
                 )

--- a/tests/test_parser_v2.py
+++ b/tests/test_parser_v2.py
@@ -416,8 +416,8 @@ def test_increasing_encryption_counter(caplog):
     assert device.encryption_counter == 1122868
 
 
-def test_same_encryption_counter_same_data(caplog):
-    """Test BTHome parser with the same encryption counter and service data."""
+def test_same_encryption_counter(caplog):
+    """Test BTHome parser with the same encryption counter."""
     bindkey = "231d39c1d7cc1ab1aee224cd096db932"
     data_string = b"\x41\xe4\x45\xf3\xc9\x96\x2b\x33\x22\x11\x00\x6c\x7c\x45\x19"
     advertisement = bytes_to_service_info(
@@ -439,13 +439,7 @@ def test_same_encryption_counter_same_data(caplog):
     )
     assert device.supported(advertisement)
     assert device.bindkey_verified
-    # encryption counter should not be updated as it is lower
     assert device.encryption_counter == 1122867
-    assert (
-        "The new encryption counter (1122867) and service data are the same as the previous "
-        "encryption counter (1122867) and service data. Skipping this message."
-        in caplog.text
-    )
 
 
 def test_decreasing_encryption_counter(caplog):
@@ -474,8 +468,8 @@ def test_decreasing_encryption_counter(caplog):
     # encryption counter should not be updated as it is lower
     assert device.encryption_counter == 1122867
     assert (
-        "The new encryption counter (1122866) is lower than or equal to the previous value "
-        "(1122867). The data might be compromised. BLE advertisement will be skipped."
+        "The new encryption counter (1122866) is lower than the previous value (1122867). "
+        "The data might be compromised. BLE advertisement will be skipped."
         in caplog.text
     )
 

--- a/tests/test_parser_v2.py
+++ b/tests/test_parser_v2.py
@@ -59,8 +59,8 @@ KEY_VOC = DeviceKey(key="volatile_organic_compounds", device_id=None)
 KEY_VOLTAGE = DeviceKey(key="voltage", device_id=None)
 KEY_VOLUME = DeviceKey(key="volume", device_id=None)
 KEY_VOLUME_FLOW_RATE = DeviceKey(key="volume_flow_rate", device_id=None)
+KEY_VOLUME_STORAGE = DeviceKey(key="volume_storage", device_id=None)
 KEY_WATER = DeviceKey(key="water", device_id=None)
-KEY_WATER_STORAGE = DeviceKey(key="water_storage", device_id=None)
 
 
 @pytest.fixture(autouse=True)
@@ -2700,8 +2700,8 @@ def test_bthome_text_invalid(caplog):
     )
 
 
-def test_bthome_water_storage(caplog):
-    """Test BTHome parser for water storage in Liters."""
+def test_bthome_volume_storage(caplog):
+    """Test BTHome parser for volume storage in Liters."""
     data_string = b"\x40\x55\x87\x56\x2a\x01"
     advertisement = bytes_to_service_info(
         data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
@@ -2721,9 +2721,9 @@ def test_bthome_water_storage(caplog):
             )
         },
         entity_descriptions={
-            KEY_WATER_STORAGE: SensorDescription(
-                device_key=KEY_WATER_STORAGE,
-                device_class=ExtendedSensorDeviceClass.WATER_STORAGE,
+            KEY_VOLUME_STORAGE: SensorDescription(
+                device_key=KEY_VOLUME_STORAGE,
+                device_class=ExtendedSensorDeviceClass.VOLUME_STORAGE,
                 native_unit_of_measurement=Units.VOLUME_LITERS,
             ),
             KEY_SIGNAL_STRENGTH: SensorDescription(
@@ -2733,9 +2733,9 @@ def test_bthome_water_storage(caplog):
             ),
         },
         entity_values={
-            KEY_WATER_STORAGE: SensorValue(
-                device_key=KEY_WATER_STORAGE,
-                name="Water Storage",
+            KEY_VOLUME_STORAGE: SensorValue(
+                device_key=KEY_VOLUME_STORAGE,
+                name="Volume Storage",
                 native_value=19551.879,
             ),
             KEY_SIGNAL_STRENGTH: SensorValue(


### PR DESCRIPTION
fix: allow encryption counter to be the same, to allow for messages that are split in different submessages (fix #99)