### PR TITLE
feat(bthome): add direction and precipitation support

### DIFF
--- a/src/bthome_ble/const.py
+++ b/src/bthome_ble/const.py
@@ -37,6 +37,12 @@ class ExtendedSensorDeviceClass(BaseDeviceClass):
     # Volume storage
     VOLUME_STORAGE = "volume_storage"
 
+    # Direction
+    DIRECTION = "direction"
+
+    # Precipitation
+    PRECIPITATION = "precipitation"
+
 
 class ExtendedSensorLibrary(SensorLibrary):
     """Sensor Library for additional sensors (compared to sensor-state-data)."""
@@ -54,6 +60,16 @@ class ExtendedSensorLibrary(SensorLibrary):
     VOLUME_STORAGE__VOLUME_LITERS = description.BaseSensorDescription(
         device_class=ExtendedSensorDeviceClass.VOLUME_STORAGE,
         native_unit_of_measurement=Units.VOLUME_LITERS,
+    )
+
+    DIRECTION__DEGREE = description.BaseSensorDescription(
+        device_class=ExtendedSensorDeviceClass.DIRECTION,
+        native_unit_of_measurement=Units.DEGREE,
+    )
+
+    PRECIPITATION__LENGTH_MILLIMETERS = description.BaseSensorDescription(
+        device_class=ExtendedSensorDeviceClass.PRECIPITATION,
+        native_unit_of_measurement=Units.LENGTH_MILLIMETERS,
     )
 
 
@@ -449,5 +465,15 @@ MEAS_TYPES: dict[int, MeasTypes] = {
         data_length=2,
         factor=0.001,
         data_format="signed_integer",
+    ),
+    0x5E: MeasTypes(
+        meas_format=ExtendedSensorLibrary.DIRECTION__DEGREE,
+        data_length=2,
+        factor=0.01,
+    ),
+    0x5F: MeasTypes(
+        meas_format=ExtendedSensorLibrary.PRECIPITATION__LENGTH_MILLIMETERS,
+        data_length=2,
+        factor=1,
     ),
 }

--- a/tests/test_parser_v2.py
+++ b/tests/test_parser_v2.py
@@ -3923,3 +3923,57 @@ def test_bthome_invalid_object_payload_data_length(caplog):
     device = BTHomeBluetoothDeviceData()
     device.update(advertisement)
     assert "ATC 18B2: Invalid payload data length, payload: 02ca0903bf" in caplog.text
+
+
+def test_bthome_direction_precipitation(caplog):
+    """Test BTHome parser for Direction(0x5E) and Precipitation(0x5F) without encryption."""
+    data_string = b"\x40\x5E\x3F\x75\x5F\x11\xD5"
+    advertisement = bytes_to_service_info(
+        data_string, local_name="SBWS-90CM", address="A4:C1:38:55:AA:55"
+    )
+
+    device = BTHomeBluetoothDeviceData()
+    assert device.update(advertisement) == SensorUpdate(
+        title="SBWS-90CM AA55",
+        devices={
+            None: SensorDeviceInfo(
+                name="SBWS-90CM AA55",
+                manufacturer=None,
+                model="BTHome sensor",
+                sw_version="BTHome BLE v2",
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="direction", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="direction", device_id=None),
+                device_class=ExtendedSensorDeviceClass.DIRECTION,
+                native_unit_of_measurement=Units.DEGREE,
+            ),
+            DeviceKey(key="precipitation", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="precipitation", device_id=None),
+                device_class=ExtendedSensorDeviceClass.PRECIPITATION,
+                native_unit_of_measurement=Units.LENGTH_MILLIMETERS,
+            ),
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="direction", device_id=None): SensorValue(
+                device_key=DeviceKey(key="direction", device_id=None),
+                name="Direction",
+                native_value=300.15,
+            ),
+            DeviceKey(key="precipitation", device_id=None): SensorValue(
+                device_key=DeviceKey(key="precipitation", device_id=None),
+                name="Precipitation",
+                native_value=54545,
+            ),
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60
+            ),
+        },
+    )


### PR DESCRIPTION
Added property 'direction' 0x5E, in degrees, precision: 0.01, 2 bytes unsigned
Added property 'precipitation' 0x5F in mm, precision: 1, 2 bytes unsigned

Related document change:
[Document change](https://github.com/home-assistant/bthome.io/pull/53)