### PR TITLE
feat (bthome): Add channel data type

### DIFF
--- a/src/bthome_ble/const.py
+++ b/src/bthome_ble/const.py
@@ -28,6 +28,9 @@ class MeasTypes:
 class ExtendedSensorDeviceClass(BaseDeviceClass):
     """Device class for additional sensors (compared to sensor-state-data)."""
 
+    # Data channel
+    CHANNEL = "channel"
+
     # Raw hex data
     RAW = "raw"
 
@@ -70,6 +73,10 @@ class ExtendedSensorLibrary(SensorLibrary):
     PRECIPITATION__LENGTH_MILLIMETERS = description.BaseSensorDescription(
         device_class=ExtendedSensorDeviceClass.PRECIPITATION,
         native_unit_of_measurement=Units.LENGTH_MILLIMETERS,
+    )
+    CHANNEL__NONE = description.BaseSensorDescription(
+        device_class=ExtendedSensorDeviceClass.CHANNEL,
+        native_unit_of_measurement=None,
     )
 
 
@@ -476,4 +483,5 @@ MEAS_TYPES: dict[int, MeasTypes] = {
         data_length=2,
         factor=1,
     ),
+    0x60: MeasTypes(meas_format=ExtendedSensorLibrary.CHANNEL__NONE),
 }

--- a/tests/test_parser_v2.py
+++ b/tests/test_parser_v2.py
@@ -3978,6 +3978,7 @@ def test_bthome_direction_precipitation(caplog):
         },
     )
 
+
 def test_bthome_channel(caplog):
     """Test BTHome parser for Channel(0x60) without encryption."""
     data_string = b"\x40\x60\x01"
@@ -4020,4 +4021,3 @@ def test_bthome_channel(caplog):
             ),
         },
     )
-

--- a/tests/test_parser_v2.py
+++ b/tests/test_parser_v2.py
@@ -3977,3 +3977,47 @@ def test_bthome_direction_precipitation(caplog):
             ),
         },
     )
+
+def test_bthome_channel(caplog):
+    """Test BTHome parser for Channel(0x60) without encryption."""
+    data_string = b"\x40\x60\x01"
+    advertisement = bytes_to_service_info(
+        data_string, local_name="SBRC-005B", address="28:DB:A7:B5:D4:03"
+    )
+
+    device = BTHomeBluetoothDeviceData()
+    assert device.update(advertisement) == SensorUpdate(
+        title="SBRC-005B D403",
+        devices={
+            None: SensorDeviceInfo(
+                name="SBRC-005B D403",
+                manufacturer=None,
+                model="BTHome sensor",
+                sw_version="BTHome BLE v2",
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            DeviceKey(key="channel", device_id=None): SensorDescription(
+                device_key=DeviceKey(key="channel", device_id=None),
+                device_class=ExtendedSensorDeviceClass.CHANNEL,
+                native_unit_of_measurement=None,
+            ),
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+        },
+        entity_values={
+            DeviceKey(key="channel", device_id=None): SensorValue(
+                device_key=DeviceKey(key="channel", device_id=None),
+                name="Channel",
+                native_value=1,
+            ),
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60
+            ),
+        },
+    )
+


### PR DESCRIPTION
The use of new type "Channel" is to allow sensor data from multiple arrays of identical sensors to be transmitted