### PR TITLE
fix: replace python-semantic-release/upload-to-gh-release with python-semantic-release/publish-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,12 +86,9 @@ jobs:
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: steps.release.outputs.released == 'true'
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
 
       - name: Publish package to GitHub Release
-        uses: python-semantic-release/upload-to-gh-release@v9.8.9
+        uses: python-semantic-release/publish-action@v9.21.0
         if: steps.release.outputs.released == 'true'
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
[python-semantic-release/upload-to-gh-release](https://github.com/python-semantic-release/upload-to-gh-release) has been retired and replaced with [python-semantic-release/publish-action](https://github.com/python-semantic-release/publish-action)

additionally we have trusted publishing set up now so the token is no longer needed and can be deleted.