### PR TITLE
fix: encryption length check

### DIFF
--- a/src/bthome_ble/bthome_v1_encryption.py
+++ b/src/bthome_ble/bthome_v1_encryption.py
@@ -45,7 +45,7 @@ def decrypt_aes_ccm(key: bytes, mac: bytes, data: bytes) -> dict[str, float] | N
     print("MAC:", mac.hex())
     print("Bindkey:", key.hex())
     adslength = len(data)
-    if adslength > 15 and data[0] == 0x1E and data[1] == 0x18:
+    if adslength > 12 and data[0] == 0x1E and data[1] == 0x18:
         pkt = data[: data[0] + 1]
         uuid = pkt[0:2]
         encrypted_data = pkt[2:-8]

--- a/src/bthome_ble/bthome_v2_encryption.py
+++ b/src/bthome_ble/bthome_v2_encryption.py
@@ -15,6 +15,10 @@ def parse_value(data: bytes) -> dict[str, float]:
         humi = round(int.from_bytes(data[4:6], "little", signed=False) * 0.01, 2)
         print("Temperature:", temp, "Humidity:", humi)
         return {"temperature": temp, "humidity": humi}
+    elif vlength == 2:
+        motion = data[1]
+        print("Motion:", motion)
+        return {"Motion": motion}
     print("MsgLength:", vlength, "HexValue:", data.hex())
     return {}
 
@@ -45,7 +49,7 @@ def decrypt_aes_ccm(key: bytes, mac: bytes, data: bytes) -> dict[str, float] | N
     print("MAC:", mac.hex())
     print("Bindkey:", key.hex())
     adslength = len(data)
-    if adslength > 15 and data[0] == 0xD2 and data[1] == 0xFC:
+    if adslength > 12 and data[0] == 0xD2 and data[1] == 0xFC:
         pkt = data[: data[0] + 1]
         uuid = pkt[0:2]
         sw_version = pkt[2:3]
@@ -90,7 +94,7 @@ def main() -> None:
     """Example to encrypt and decrypt BTHome payload."""
     print()
     print("====== Test encode -----------------------------------------")
-    data = bytes(bytearray.fromhex("02CA0903BF13"))  # BTHome data (not encrypted)
+    data = bytes(bytearray.fromhex("02CA09"))  # BTHome data (not encrypted)
     parse_value(data)  # Print temperature and humidity
 
     print()

--- a/src/bthome_ble/parser.py
+++ b/src/bthome_ble/parser.py
@@ -326,6 +326,26 @@ class BTHomeBluetoothDeviceData(BluetoothData):
             manufacturer = "Shelly"
             name = "Shelly BLU Door/Window"
             device_type = "BLU Door/Window"
+        elif name == "SBMO-003Z":
+            manufacturer = "Shelly"
+            name = "Shelly BLU Motion"
+            device_type = "BLU Motion"
+        elif name == "SBHT-003C":
+            manufacturer = "Shelly"
+            name = "Shelly BLU H&T"
+            device_type = "BLU H&T"
+        elif name == "SBBT-004CEU":
+            manufacturer = "Shelly"
+            name = "Shelly BLU Wall Switch 4"
+            device_type = "BLU Wall Switch 4"
+        elif name == "SBBT-004CUS":
+            manufacturer = "Shelly"
+            name = "Shelly BLU RC Button 4"
+            device_type = "BLU RC Button 4"
+        elif name == "SBTR-001AEU":
+            manufacturer = "Shelly"
+            name = "Shelly BLU TRV"
+            device_type = "BLU TRV"
         else:
             manufacturer = None
             device_type = "BTHome sensor"

--- a/src/bthome_ble/parser.py
+++ b/src/bthome_ble/parser.py
@@ -318,11 +318,11 @@ class BTHomeBluetoothDeviceData(BluetoothData):
             manufacturer = "b-parasite"
             name = "b-parasite"
             device_type = "Plant sensor"
-        elif name.startswith("SBBT"):
+        elif name == "SBBT-002C":
             manufacturer = "Shelly"
             name = "Shelly BLU Button1"
             device_type = "BLU Button1"
-        elif name.startswith("SBDW"):
+        elif name == "SBDW-002C":
             manufacturer = "Shelly"
             name = "Shelly BLU Door/Window"
             device_type = "BLU Door/Window"
@@ -609,7 +609,7 @@ class BTHomeBluetoothDeviceData(BluetoothData):
             raise ValueError
 
         # check for minimum length of encrypted advertisement
-        if len(service_data) < (12 if sw_version == 1 else 11):
+        if len(service_data) < (12 if sw_version == 1 else 10):
             _LOGGER.debug(
                 "%s: Invalid data length (for decryption), adv: %s",
                 self.title,

--- a/tests/test_parser_v2.py
+++ b/tests/test_parser_v2.py
@@ -283,7 +283,7 @@ def test_bindkey_correct():
     data_string = b"\x41\xa4\x72\x66\xc9\x5f\x73\x00\x11\x22\x33\x78\x23\x72\x14"
     advertisement = bytes_to_service_info(
         data_string,
-        local_name="TEST DEVICE",
+        local_name="SBHT-003C",
         address="54:48:E6:8F:80:A5",
     )
 
@@ -292,12 +292,12 @@ def test_bindkey_correct():
     assert device.bindkey_verified
     assert not device.decryption_failed
     assert device.update(advertisement) == SensorUpdate(
-        title="TEST DEVICE 80A5",
+        title="Shelly BLU H&T 80A5",
         devices={
             None: SensorDeviceInfo(
-                name="TEST DEVICE 80A5",
-                manufacturer=None,
-                model="BTHome sensor",
+                name="Shelly BLU H&T 80A5",
+                manufacturer="Shelly",
+                model="BLU H&T",
                 sw_version="BTHome BLE v2 (encrypted)",
                 hw_version=None,
             )
@@ -1752,18 +1752,18 @@ def test_bthome_motion(caplog):
     bindkey = "231d39c1d7cc1ab1aee224cd096db932"
     data_string = b"\x41\x87\xb9\x00\x11\x22\x33\x72\xb0\x23\x1f"
     advertisement = bytes_to_service_info(
-        data_string, local_name="BTHome sensor", address="54:48:E6:8F:80:A5"
+        data_string, local_name="SBMO-003Z", address="54:48:E6:8F:80:A5"
     )
 
     device = BTHomeBluetoothDeviceData(bindkey=bytes.fromhex(bindkey))
 
     assert device.update(advertisement) == SensorUpdate(
-        title="BTHome sensor 80A5",
+        title="Shelly BLU Motion 80A5",
         devices={
             None: SensorDeviceInfo(
-                name="BTHome sensor 80A5",
-                manufacturer=None,
-                model="BTHome sensor",
+                name="Shelly BLU Motion 80A5",
+                manufacturer="Shelly",
+                model="BLU Motion",
                 sw_version="BTHome BLE v2 (encrypted)",
                 hw_version=None,
             )
@@ -1844,18 +1844,18 @@ def test_bthome_event_triple_button_device(caplog):
     """
     data_string = b"\x40\x3a\x00\x3a\x01\x3a\x03"
     advertisement = bytes_to_service_info(
-        data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
+        data_string, local_name="SBBT-004CEU", address="A4:C1:38:8D:18:B2"
     )
 
     device = BTHomeBluetoothDeviceData()
 
     assert device.update(advertisement) == SensorUpdate(
-        title="TEST DEVICE 18B2",
+        title="Shelly BLU Wall Switch 4 18B2",
         devices={
             None: SensorDeviceInfo(
-                name="TEST DEVICE 18B2",
-                manufacturer=None,
-                model="BTHome sensor",
+                name="Shelly BLU Wall Switch 4 18B2",
+                manufacturer="Shelly",
+                model="BLU Wall Switch 4",
                 sw_version="BTHome BLE v2",
                 hw_version=None,
             )
@@ -1893,18 +1893,18 @@ def test_bthome_event_button_hold_press(caplog):
     """Test BTHome parser for an event of holding press on a button without encryption."""
     data_string = b"\x40\x3a\x80"
     advertisement = bytes_to_service_info(
-        data_string, local_name="SBBT-002C", address="A4:C1:38:8D:18:B2"
+        data_string, local_name="SBBT-004CUS", address="A4:C1:38:8D:18:B2"
     )
 
     device = BTHomeBluetoothDeviceData()
 
     assert device.update(advertisement) == SensorUpdate(
-        title="Shelly BLU Button1 18B2",
+        title="Shelly BLU RC Button 4 18B2",
         devices={
             None: SensorDeviceInfo(
-                name="Shelly BLU Button1 18B2",
+                name="Shelly BLU RC Button 4 18B2",
                 manufacturer="Shelly",
-                model="BLU Button1",
+                model="BLU RC Button 4",
                 sw_version="BTHome BLE v2",
                 hw_version=None,
             )
@@ -2289,18 +2289,18 @@ def test_bthome_temperature_2(caplog):
     """Test BTHome parser for temperature with one digit."""
     data_string = b"\x40\x45\x11\x01"
     advertisement = bytes_to_service_info(
-        data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
+        data_string, local_name="SBTR-001AEU", address="A4:C1:38:8D:18:B2"
     )
 
     device = BTHomeBluetoothDeviceData()
 
     assert device.update(advertisement) == SensorUpdate(
-        title="TEST DEVICE 18B2",
+        title="Shelly BLU TRV 18B2",
         devices={
             None: SensorDeviceInfo(
-                name="TEST DEVICE 18B2",
-                manufacturer=None,
-                model="BTHome sensor",
+                name="Shelly BLU TRV 18B2",
+                manufacturer="Shelly",
+                model="BLU TRV",
                 sw_version="BTHome BLE v2",
                 hw_version=None,
             )

--- a/tests/test_parser_v2.py
+++ b/tests/test_parser_v2.py
@@ -29,6 +29,7 @@ KEY_ACCELERATION = DeviceKey(key="acceleration", device_id=None)
 KEY_BATTERY = DeviceKey(key="battery", device_id=None)
 KEY_BINARY_GENERIC = DeviceKey(key="generic", device_id=None)
 KEY_BINARY_OPENING = DeviceKey(key="opening", device_id=None)
+KEY_BINARY_MOTION = DeviceKey(key="motion", device_id=None)
 KEY_BINARY_POWER = DeviceKey(key="power", device_id=None)
 KEY_BINARY_WINDOW = DeviceKey(key="window", device_id=None)
 KEY_BUTTON = DeviceKey(key="button", device_id=None)
@@ -1741,6 +1742,53 @@ def test_bthome_moisture(caplog):
             ),
             KEY_SIGNAL_STRENGTH: SensorValue(
                 device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60
+            ),
+        },
+    )
+
+
+def test_bthome_motion(caplog):
+    """Test BTHome parser for motion reading from sensor."""
+    bindkey = "231d39c1d7cc1ab1aee224cd096db932"
+    data_string = b"\x41\x87\xb9\x00\x11\x22\x33\x72\xb0\x23\x1f"
+    advertisement = bytes_to_service_info(
+        data_string, local_name="BTHome sensor", address="54:48:E6:8F:80:A5"
+    )
+
+    device = BTHomeBluetoothDeviceData(bindkey=bytes.fromhex(bindkey))
+
+    assert device.update(advertisement) == SensorUpdate(
+        title="BTHome sensor 80A5",
+        devices={
+            None: SensorDeviceInfo(
+                name="BTHome sensor 80A5",
+                manufacturer=None,
+                model="BTHome sensor",
+                sw_version="BTHome BLE v2 (encrypted)",
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+        },
+        entity_values={
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60
+            ),
+        },
+        binary_entity_descriptions={
+            KEY_BINARY_MOTION: BinarySensorDescription(
+                device_key=KEY_BINARY_MOTION,
+                device_class=BinarySensorDeviceClass.MOTION,
+            ),
+        },
+        binary_entity_values={
+            KEY_BINARY_MOTION: BinarySensorValue(
+                device_key=KEY_BINARY_MOTION, name="Motion", native_value=True
             ),
         },
     )

--- a/tests/test_v2_encryption.py
+++ b/tests/test_v2_encryption.py
@@ -5,7 +5,7 @@ import binascii
 from bthome_ble.bthome_v2_encryption import decrypt_aes_ccm, encrypt_payload
 
 
-def test_encryption_example():
+def test_encryption_example_1():
     """Test BTHome V2 encryption example."""
     data = bytes(bytearray.fromhex("02CA0903BF13"))  # BTHome data (not encrypted)
     count_id = bytes(bytearray.fromhex("00112233"))  # count id (change every message)
@@ -29,4 +29,28 @@ def test_encryption_example():
     assert decrypt_aes_ccm(key=bindkey, mac=mac, data=encrypted_payload) == {
         "humidity": 50.55,
         "temperature": 25.06,
+    }
+
+
+def test_encryption_example_2():
+    """Test BTHome V2 encryption example."""
+    data = bytes(bytearray.fromhex("2101"))  # BTHome data (not encrypted)
+    count_id = bytes(bytearray.fromhex("00112233"))  # count id (change every message)
+    mac = binascii.unhexlify("5448E68F80A5")  # MAC
+    uuid16 = b"\xd2\xfc"
+    sw_version = b"\x41"
+    bindkey = binascii.unhexlify("231d39c1d7cc1ab1aee224cd096db932")
+
+    encrypted_payload = encrypt_payload(
+        data=data,
+        mac=mac,
+        uuid16=uuid16,
+        sw_version=sw_version,
+        count_id=count_id,
+        key=bindkey,
+    )
+    print(encrypted_payload.hex())
+    assert encrypted_payload == b"\xd2\xfc\x41\x87\xb9\x00\x11\x22\x33\x72\xb0\x23\x1f"
+    assert decrypt_aes_ccm(key=bindkey, mac=mac, data=encrypted_payload) == {
+        "Motion": 1,
     }


### PR DESCRIPTION
- fix: encrypted data is checked for its length, but two bytes data (like binary sensors) were marked as invalid due the the length check. This has been fixed (fix #254)
- fix: new shelly devices are now being detected correctly (fix #215)