### PR TITLE
doc: start replacing is_mac_included

### DIFF
--- a/src/bthome_ble/parser.py
+++ b/src/bthome_ble/parser.py
@@ -294,6 +294,16 @@ class BTHomeData:
             case _:
                 raise ValueError
 
+    def is_mac_included_privately(self) -> bool:
+        """Checks if the MAC is included privatly flag is set."""
+        match self.get_bthome_version():
+            case BTHomeVersion.V1:
+                return False
+            case BTHomeVersion.V2:
+                return self._is_mac_included_privately()
+            case _:
+                raise ValueError
+
     def get_nounce_uuid(self) -> bytes:
         """Returns the UUID for the nounce."""
         match self.get_bthome_version():
@@ -346,7 +356,7 @@ class BTHomeData:
         counter = self.get_counter()
         uuid = self.get_nounce_uuid()
         # TODO tests are needed
-        if self._is_mac_included_privately():
+        if self.is_mac_included_privately():
             # nonce: uuid16 [2 (v1) or 3 (v2)], counter [4]
             return b"".join([uuid, counter])
         mac_readable = self.get_mac_readable()
@@ -587,12 +597,9 @@ class BTHomeBluetoothDeviceData(BluetoothData):
         if payload is None:
             return True
         # TODO tests are needed
-        if (
-            bthome_data._is_mac_included_privately()
-        ):  # TODO method is marked private still
-            payload = payload[
-                6:
-            ]  # TODO the mac itself (payload[:6]) is not usable anymore
+        if bthome_data.is_mac_included_privately():
+            # TODO the mac itself (payload[:6]) is not usable anymore
+            payload = payload[6:]
 
         return self._parse_payload(payload, bthome_data.get_time())
 

--- a/src/bthome_ble/parser.py
+++ b/src/bthome_ble/parser.py
@@ -71,6 +71,11 @@ def is_encrypted(service_data: bytes) -> bool:
 def is_mac_included(service_data: bytes) -> bool:
     """Checks if the MAC is included flag is set."""
     # If True, the first 6 bytes contain the mac address
+    # This is an undocumented deprecated and risky feature, due to privacy reasons
+    # It will not make it into the official documentation.
+    # It was implemented to adsress issue #42
+    # https://github.com/Bluetooth-Devices/bthome-ble/issues/42
+    # Do not use it. Use "is_mac_included_safe" instead.
     return bool(get_adv_info(service_data) & (1 << 1))  # bit 1
 
 
@@ -78,6 +83,15 @@ def is_sleepy_device(service_data: bytes) -> bool:
     """Checks if device is sleepy flag is set."""
     # If True, the device is only updating when trigger
     return bool(get_adv_info(service_data) & (1 << 2))  # bit 2
+
+
+def is_mac_included_safe(service_data: bytes) -> bool:
+    """Checks if the MAC is included safe flag is set."""
+    # If True, the first 6 bytes of the decrypted payload contain the mac address
+    # and mac address is not used for nonce anymore. It is recommended to use that
+    # feature only in combination with "is_encrypted".
+    # NOT YET IMPLEMENTED.
+    return bool(get_adv_info(service_data) & (1 << 3))  # bit 3
 
 
 def get_version(service_data: bytes) -> int:


### PR DESCRIPTION
This is just a starting point to get early feedback, replace PR #323 and continue discussion on issue #42.

Not implemented yet and not ready to merge.

This would be my ~~first~~ second proposal to solve use case described in issue https://github.com/Bluetooth-Devices/bthome-ble/issues/42:

1. ~~Generally~~ do not use MAC address of the device in the nonce.
2. Instead put it as the first 6 bytes of the unencrypted payload.
3. Encrypt this payload if requested by associated flag.
4. Thus the MAC is hidden in encrypted mode.
5. When decrypting, MAC address is not needed anymore (in nonce).
6. After decryption the MAC address is known now.

We can burn another bit in the adv_info to support that mode (is_mac_included_privately).

To decide later:
With V3 of BTHome we can make that obligatory and can free that bit again, but this needs always 6 extra bytes?! 
Thus we will have the MAC address in encrypted and unencrypted mode. In unencrypted mode and environments that hide/randomize the MAC like MacOS we can still map the advertisement to the correct device. In encrypted mode we automatically will have privacy if the environment supports that by hiding/randomizing the MAC address. Encryption will be recommended if privacy is needed.