### PR TITLE
feat(sensor): add settings revision (0x65)

### DIFF
--- a/src/bthome_ble/const.py
+++ b/src/bthome_ble/const.py
@@ -52,6 +52,9 @@ class ExtendedSensorDeviceClass(BaseDeviceClass):
     # Rotational speed
     ROTATIONAL_SPEED = "rotational_speed"
 
+    # Settings revision
+    SETTINGS_REVISION = "settings_revision"
+
 
 class ExtendedSensorLibrary(SensorLibrary):
     """Sensor Library for additional sensors (compared to sensor-state-data)."""
@@ -94,6 +97,11 @@ class ExtendedSensorLibrary(SensorLibrary):
     ROTATIONAL_SPEED__REVOLUTIONS_PER_MINUTE = description.BaseSensorDescription(
         device_class=ExtendedSensorDeviceClass.ROTATIONAL_SPEED,
         native_unit_of_measurement=Units.REVOLUTIONS_PER_MINUTE,
+    )
+
+    SETTINGS_REVISION__NONE = description.BaseSensorDescription(
+        device_class=ExtendedSensorDeviceClass.SETTINGS_REVISION,
+        native_unit_of_measurement=None,
     )
 
 
@@ -518,4 +526,5 @@ MEAS_TYPES: dict[int, MeasTypes] = {
         data_format="signed_integer",
     ),
     0x64: MeasTypes(meas_format=ExtendedSensorLibrary.LIGHT_LEVEL__NONE),
+    0x65: MeasTypes(meas_format=ExtendedSensorLibrary.SETTINGS_REVISION__NONE),
 }

--- a/tests/test_parser_v2.py
+++ b/tests/test_parser_v2.py
@@ -69,6 +69,7 @@ KEY_VOLUME_STORAGE = DeviceKey(key="volume_storage", device_id=None)
 KEY_WATER = DeviceKey(key="water", device_id=None)
 KEY_CONDUCTIVITY = DeviceKey(key="conductivity", device_id=None)
 KEY_LIGHT_LEVEL = DeviceKey(key="light_level", device_id=None)
+KEY_SETTINGS_REVISION = DeviceKey(key="settings_revision", device_id=None)
 
 
 @pytest.fixture(autouse=True)
@@ -4532,6 +4533,50 @@ def test_bthome_light_level(caplog):
                 device_key=KEY_LIGHT_LEVEL,
                 name="Light Level",
                 native_value=2,
+            ),
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60
+            ),
+        },
+    )
+
+
+def test_bthome_settings_revision(caplog):
+    """Test BTHome parser for Settings Revision (0x65) without encryption."""
+    data_string = b"\x40\x65\x03"
+    advertisement = bytes_to_service_info(
+        data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
+    )
+
+    device = BTHomeBluetoothDeviceData()
+    assert device.update(advertisement) == SensorUpdate(
+        title="TEST DEVICE 18B2",
+        devices={
+            None: SensorDeviceInfo(
+                name="TEST DEVICE 18B2",
+                manufacturer=None,
+                model="BTHome sensor",
+                sw_version="BTHome BLE v2",
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            KEY_SETTINGS_REVISION: SensorDescription(
+                device_key=KEY_SETTINGS_REVISION,
+                device_class=ExtendedSensorDeviceClass.SETTINGS_REVISION,
+                native_unit_of_measurement=None,
+            ),
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+        },
+        entity_values={
+            KEY_SETTINGS_REVISION: SensorValue(
+                device_key=KEY_SETTINGS_REVISION,
+                name="Settings Revision",
+                native_value=3,
             ),
             KEY_SIGNAL_STRENGTH: SensorValue(
                 device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60


### PR DESCRIPTION
## Summary

Adds support for a new sensor object ID `0x65` — **settings revision**.

`settings revision` is a monotonic `uint8` counter (0–255, wraps to 0 after 255) that a device uses to notify observers that its internal, non-broadcast configuration — setpoints, thresholds, schedules, pairings, calibration, operating mode, or any other configurable parameter not already exposed as a sensor value — has changed.

Observers detect a change by comparing the current value to the previously seen value; any difference indicates that interested consumers should re-read the relevant data out-of-band (e.g. via a GATT connection). The device does not describe *what* changed; it only notifies that *something* changed.

## Changes

- `src/bthome_ble/const.py`: new `ExtendedSensorDeviceClass.SETTINGS_REVISION`, `ExtendedSensorLibrary.SETTINGS_REVISION__NONE`, and the `0x65` entry in `MEAS_TYPES`.
- `tests/test_parser_v2.py`: new `test_bthome_settings_revision` test covering unencrypted parsing.

## Format spec

Accompanying spec change in `home-assistant/bthome.io`: https://github.com/home-assistant/bthome.io/pull/73

## Test plan

- `pytest` — all 138 tests pass (137 previous + 1 new).