### PR TITLE
feat(event): add command object (0xE0)

### DIFF
--- a/src/bthome_ble/const.py
+++ b/src/bthome_ble/const.py
@@ -522,7 +522,7 @@ MEAS_TYPES: dict[int, MeasTypes] = {
     0x63: MeasTypes(
         meas_format=SensorLibrary.ACCELERATION__ACCELERATION_METERS_PER_SQUARE_SECOND,
         data_length=4,
-         factor=0.000001,
+        factor=0.000001,
         data_format="signed_integer",
     ),
     0x64: MeasTypes(meas_format=ExtendedSensorLibrary.LIGHT_LEVEL__NONE),

--- a/src/bthome_ble/const.py
+++ b/src/bthome_ble/const.py
@@ -522,9 +522,13 @@ MEAS_TYPES: dict[int, MeasTypes] = {
     0x63: MeasTypes(
         meas_format=SensorLibrary.ACCELERATION__ACCELERATION_METERS_PER_SQUARE_SECOND,
         data_length=4,
-        factor=0.000001,
+         factor=0.000001,
         data_format="signed_integer",
     ),
     0x64: MeasTypes(meas_format=ExtendedSensorLibrary.LIGHT_LEVEL__NONE),
     0x65: MeasTypes(meas_format=ExtendedSensorLibrary.SETTINGS_REVISION__NONE),
+    0xE0: MeasTypes(
+        meas_format=EventDeviceKeys.COMMAND,
+        data_format="command",
+    ),
 }

--- a/src/bthome_ble/event.py
+++ b/src/bthome_ble/event.py
@@ -17,6 +17,9 @@ class EventDeviceKeys(StrEnum):
     # Button
     BUTTON = "button"
 
+    # Command
+    COMMAND = "command"
+
 
 BUTTON_EVENTS: dict[int, str | None] = {
     0x00: None,
@@ -33,4 +36,12 @@ DIMMER_EVENTS: dict[int, str | None] = {
     0x00: None,
     0x01: "rotate_left",
     0x02: "rotate_right",
+}
+
+COMMAND_EVENTS: dict[int, str | None] = {
+    0x00: "off",
+    0x01: "on",
+    0x02: "toggle",
+    0x03: "step_up",
+    0x04: "step_down",
 }

--- a/src/bthome_ble/parser.py
+++ b/src/bthome_ble/parser.py
@@ -28,7 +28,7 @@ from sensor_state_data.description import (
 )
 
 from .const import MEAS_TYPES
-from .event import BUTTON_EVENTS, DIMMER_EVENTS, EventDeviceKeys
+from .event import BUTTON_EVENTS, COMMAND_EVENTS, DIMMER_EVENTS, EventDeviceKeys
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -138,6 +138,8 @@ def parse_event_type(event_device: str, data_obj: int) -> str | None:
         event_type = DIMMER_EVENTS.get(data_obj)
     elif event_device == "button":
         event_type = BUTTON_EVENTS.get(data_obj)
+    elif event_device == "command":
+        event_type = COMMAND_EVENTS.get(data_obj)
     else:
         event_type = None
     return event_type
@@ -150,6 +152,9 @@ def parse_event_properties(
     if event_device == "dimmer":
         # number of steps for rotating a dimmer
         return {"steps": int.from_bytes(data_obj, "little", signed=True)}
+    elif event_device == "command":
+        # manufacturer-specific arguments, exposed as hex string
+        return {"args": data_obj.hex()}
     else:
         return None
 
@@ -664,6 +669,12 @@ class BTHomeBluetoothDeviceData(BluetoothData):
                     if obj_data_format in ["raw", "string"]:
                         obj_data_length = payload[obj_start + 1]
                         obj_data_start = obj_start + 2
+                    elif obj_data_format == "command":
+                        # length byte: high 3 bits reserved, low 5 bits args length
+                        args_length = payload[obj_start + 1] & 0x1F
+                        # measurement data covers opcode + args
+                        obj_data_length = 1 + args_length
+                        obj_data_start = obj_start + 2
                     else:
                         obj_data_length = MEAS_TYPES[obj_meas_type].data_length
                         obj_data_start = obj_start + 1
@@ -751,6 +762,8 @@ class BTHomeBluetoothDeviceData(BluetoothData):
                 value = parse_raw(meas["measurement data"])
             elif meas["data format"] == 5 or meas["data format"] == "timestamp":
                 value = parse_timestamp(meas["measurement data"])
+            elif meas["data format"] == "command":
+                value = meas["measurement data"].hex()
             else:
                 _LOGGER.error(
                     "%s: UNKNOWN dataobject in BTHome BLE payload! Adv: %s",

--- a/tests/test_parser_v2.py
+++ b/tests/test_parser_v2.py
@@ -34,6 +34,7 @@ KEY_BINARY_POWER = DeviceKey(key="power", device_id=None)
 KEY_BINARY_WINDOW = DeviceKey(key="window", device_id=None)
 KEY_BUTTON = DeviceKey(key="button", device_id=None)
 KEY_CO2 = DeviceKey(key="carbon_dioxide", device_id=None)
+KEY_COMMAND = DeviceKey(key="command", device_id=None)
 KEY_DIMMER = DeviceKey(key="dimmer", device_id=None)
 KEY_DISTANCE = DeviceKey(key="distance", device_id=None)
 KEY_COUNT = DeviceKey(key="count", device_id=None)
@@ -4578,6 +4579,128 @@ def test_bthome_settings_revision(caplog):
                 name="Settings Revision",
                 native_value=3,
             ),
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60
+            ),
+        },
+    )
+
+
+def test_bthome_event_command_step_up_5(caplog):
+    """Test BTHome parser for a command event (step_up with 1-byte arg)."""
+    data_string = b"\x40\xe0\x01\x03\x05"
+    advertisement = bytes_to_service_info(
+        data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
+    )
+
+    device = BTHomeBluetoothDeviceData()
+
+    assert device.update(advertisement) == SensorUpdate(
+        title="TEST DEVICE 18B2",
+        devices={
+            None: SensorDeviceInfo(
+                name="TEST DEVICE 18B2",
+                manufacturer=None,
+                model="BTHome sensor",
+                sw_version="BTHome BLE v2",
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+        },
+        entity_values={
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60
+            ),
+        },
+        events={
+            KEY_COMMAND: Event(
+                device_key=KEY_COMMAND,
+                name="Command",
+                event_type="step_up",
+                event_properties={"args": "05"},
+            ),
+        },
+    )
+
+
+def test_bthome_event_command_toggle_no_args(caplog):
+    """Test BTHome parser for a command event with zero-length args (toggle)."""
+    data_string = b"\x40\xe0\x00\x02"
+    advertisement = bytes_to_service_info(
+        data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
+    )
+
+    device = BTHomeBluetoothDeviceData()
+
+    assert device.update(advertisement) == SensorUpdate(
+        title="TEST DEVICE 18B2",
+        devices={
+            None: SensorDeviceInfo(
+                name="TEST DEVICE 18B2",
+                manufacturer=None,
+                model="BTHome sensor",
+                sw_version="BTHome BLE v2",
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+        },
+        entity_values={
+            KEY_SIGNAL_STRENGTH: SensorValue(
+                device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60
+            ),
+        },
+        events={
+            KEY_COMMAND: Event(
+                device_key=KEY_COMMAND,
+                name="Command",
+                event_type="toggle",
+                event_properties={"args": ""},
+            ),
+        },
+    )
+
+
+def test_bthome_event_command_unknown_opcode(caplog):
+    """Test BTHome parser for a command with unknown opcode (no event fired)."""
+    # opcode 0x7F is manufacturer-specific / unknown; no standard event should fire.
+    data_string = b"\x40\xe0\x00\x7f"
+    advertisement = bytes_to_service_info(
+        data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
+    )
+
+    device = BTHomeBluetoothDeviceData()
+
+    assert device.update(advertisement) == SensorUpdate(
+        title="TEST DEVICE 18B2",
+        devices={
+            None: SensorDeviceInfo(
+                name="TEST DEVICE 18B2",
+                manufacturer=None,
+                model="BTHome sensor",
+                sw_version="BTHome BLE v2",
+                hw_version=None,
+            )
+        },
+        entity_descriptions={
+            KEY_SIGNAL_STRENGTH: SensorDescription(
+                device_key=KEY_SIGNAL_STRENGTH,
+                device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+                native_unit_of_measurement=Units.SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+            ),
+        },
+        entity_values={
             KEY_SIGNAL_STRENGTH: SensorValue(
                 device_key=KEY_SIGNAL_STRENGTH, name="Signal Strength", native_value=-60
             ),


### PR DESCRIPTION
## Summary

Adds support for a new event-type object ID `0xE0` — **command**.

The command object is variable-length:
- byte 0: `0xE0`
- byte 1: high 3 bits reserved (set to `0`), low 5 bits = argument length in bytes (0–31)
- byte 2: opcode
- bytes 3..n: arguments

Standardized opcodes: `0x00` off, `0x01` on, `0x02` toggle, `0x03` step_up, `0x04` step_down. Opcodes `0x05`–`0xFF` are reserved for future expansion and fire no event. Argument interpretation is opcode- and manufacturer-specific, exposed to consumers as a hex string in `event_properties["args"]`.

## Changes

- `src/bthome_ble/event.py`: new `EventDeviceKeys.COMMAND` and `COMMAND_EVENTS` opcode map.
- `src/bthome_ble/const.py`: new `MEAS_TYPES[0xE0]` entry with `data_format="command"`.
- `src/bthome_ble/parser.py`: variable-length parsing for `data_format="command"`, plus `"command"` handling in `parse_event_type` and `parse_event_properties`.
- `tests/test_parser_v2.py`: three new tests (step_up with args, toggle with no args, unknown opcode fires no event).

## Format spec

Accompanying spec change in `home-assistant/bthome.io`: https://github.com/home-assistant/bthome.io/pull/74

## Test plan

- `pytest` — all 140 tests pass (137 previous + 3 new).