### PR TITLE
refactor(event): move command object from 0xE0 to 0x3B

### DIFF
--- a/src/bthome_ble/const.py
+++ b/src/bthome_ble/const.py
@@ -330,6 +330,10 @@ MEAS_TYPES: dict[int, MeasTypes] = {
     0x2E: MeasTypes(meas_format=SensorLibrary.HUMIDITY__PERCENTAGE),
     0x2F: MeasTypes(meas_format=SensorLibrary.MOISTURE__PERCENTAGE),
     0x3A: MeasTypes(meas_format=EventDeviceKeys.BUTTON),
+    0x3B: MeasTypes(
+        meas_format=EventDeviceKeys.COMMAND,
+        data_format="command",
+    ),
     0x3C: MeasTypes(
         meas_format=EventDeviceKeys.DIMMER,
         data_length=2,
@@ -527,8 +531,4 @@ MEAS_TYPES: dict[int, MeasTypes] = {
     ),
     0x64: MeasTypes(meas_format=ExtendedSensorLibrary.LIGHT_LEVEL__NONE),
     0x65: MeasTypes(meas_format=ExtendedSensorLibrary.SETTINGS_REVISION__NONE),
-    0xE0: MeasTypes(
-        meas_format=EventDeviceKeys.COMMAND,
-        data_format="command",
-    ),
 }

--- a/tests/test_parser_v2.py
+++ b/tests/test_parser_v2.py
@@ -4588,7 +4588,7 @@ def test_bthome_settings_revision(caplog):
 
 def test_bthome_event_command_step_up_5(caplog):
     """Test BTHome parser for a command event (step_up with 1-byte arg)."""
-    data_string = b"\x40\xe0\x01\x03\x05"
+    data_string = b"\x40\x3b\x01\x03\x05"
     advertisement = bytes_to_service_info(
         data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
     )
@@ -4631,7 +4631,7 @@ def test_bthome_event_command_step_up_5(caplog):
 
 def test_bthome_event_command_toggle_no_args(caplog):
     """Test BTHome parser for a command event with zero-length args (toggle)."""
-    data_string = b"\x40\xe0\x00\x02"
+    data_string = b"\x40\x3b\x00\x02"
     advertisement = bytes_to_service_info(
         data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
     )
@@ -4675,7 +4675,7 @@ def test_bthome_event_command_toggle_no_args(caplog):
 def test_bthome_event_command_unknown_opcode(caplog):
     """Test BTHome parser for a command with unknown opcode (no event fired)."""
     # opcode 0x7F is manufacturer-specific / unknown; no standard event should fire.
-    data_string = b"\x40\xe0\x00\x7f"
+    data_string = b"\x40\x3b\x00\x7f"
     advertisement = bytes_to_service_info(
         data_string, local_name="TEST DEVICE", address="A4:C1:38:8D:18:B2"
     )


### PR DESCRIPTION
## Summary

Follow-up to #353. Moves the command event object from `0xE0` to `0x3B` so that all event-type objects (button `0x3A`, command `0x3B`, dimmer `0x3C`) sit together in the same object-ID range.

Suggested by @Ernst79 in the review of #353.

## Changes

- `src/bthome_ble/const.py`: `MEAS_TYPES` entry moved from `0xE0` to `0x3B`, placed between `0x3A` (button) and `0x3C` (dimmer).
- `tests/test_parser_v2.py`: updated 3 existing command test packets (`\xe0` → `\x3b`).

Parser logic is unchanged; this is purely an ID remap.

## Format spec

Matching spec change in `home-assistant/bthome.io`: https://github.com/home-assistant/bthome.io/pull/75

## Test plan

- `pytest` — all 141 tests pass.