### PR TITLE
ci: use uv to install managed Python and Poetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
-          enable-cache: true
           python-version: "3.13"
       - uses: pre-commit/action@v3.0.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,19 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  POETRY_VIRTUALENVS_IN_PROJECT: "true"
+  UV_PYTHON_PREFERENCE: only-managed
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8
         with:
+          enable-cache: true
           python-version: "3.13"
       - uses: pre-commit/action@v3.0.1
 
@@ -46,13 +52,24 @@ jobs:
     continue-on-error: ${{ matrix.python-version == '3.14' }}
     steps:
       - uses: actions/checkout@v6
-      - name: Set up Python
-        uses: actions/setup-python@v6
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8
         with:
+          enable-cache: true
           python-version: ${{ matrix.python-version }}
-      - uses: snok/install-poetry@v1
+      - name: Install poetry
+        run: uv tool install poetry
+      - name: Cache poetry venv
+        id: cache-venv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-v1-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('poetry.lock', 'pyproject.toml') }}
       - name: Install Dependencies
-        run: poetry install
+        if: steps.cache-venv.outputs.cache-hit != 'true'
+        run: |
+          poetry env use $(uv python find ${{ matrix.python-version }})
+          poetry install
       - name: Test with Pytest
         run: poetry run pytest --cov-report=xml
       - name: Upload coverage to Codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           python-version: "3.13"
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
           python-version: ${{ matrix.python-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Set up uv
         uses: astral-sh/setup-uv@v8.1.0
         with:
+          enable-cache: false
           python-version: "3.13"
       - uses: pre-commit/action@v3.0.1
 


### PR DESCRIPTION
Switches CI Python provisioning to astral uv with only managed interpreters; Poetry is installed as a uv tool and bound to the uv managed Python so jobs no longer rely on the runner's system Python.

Lint job pins 3.13 via setup-uv; test matrix unchanged.