### PR TITLE
ci: enable ruff PLC0415 to force imports at top level

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,8 +82,9 @@ select = [
     "F",     # pyflakes
     "I",     # isort
     "UP",    # pyupgrade
-    "PT006", # pytest-parametrize-names-wrong-type
-    "PT007", # pytest-parametrize-values-wrong-type
+    "PT006",   # pytest-parametrize-names-wrong-type
+    "PT007",   # pytest-parametrize-values-wrong-type
+    "PLC0415", # import-outside-top-level
 ]
 
 [tool.ruff.lint.pycodestyle]


### PR DESCRIPTION
## Summary
Enables ruff PLC0415 (import-outside-top-level), which guards against new code stashing imports inside functions or methods; the current tree has no violations so this is a future-proofing rule only.

## Details
PLC0415 catches `import` and `from ... import` statements that appear anywhere other than the module level, which keeps import cost paid once at module load and keeps the dependency surface visible at the top of each file; if a deferred import is ever genuinely needed it can be opted out with a `noqa: PLC0415` on that line.

## Test plan
- [ ] CI passes on this branch.